### PR TITLE
ci: add GoReleaser for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,26 +3,30 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 permissions:
   contents: write
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: '1.24'
 
-      - uses: goreleaser/goreleaser-action@v6
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> v2"
+          distribution: goreleaser
+          version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,25 +3,41 @@ version: 2
 project_name: hydrascale
 
 builds:
-  - main: ./cmd/hydrascale
+  - id: hydrascale
+    main: ./cmd/hydrascale
     binary: hydrascale
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
     goarch:
       - amd64
       - arm64
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w
 
 archives:
-  - format: tar.gz
+  - id: default
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE
+      - contrib/
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
 
 changelog:
-  use: git
-
-release:
-  github:
-    owner: Crank-Git
-    name: Hydrascale
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` — builds linux/amd64 and linux/arm64, tar.gz archives with checksums
- Add `.github/workflows/release.yml` — triggers on `v*` tags via `goreleaser/goreleaser-action@v6`

## Usage
After merging, cut a release with:
```bash
git tag v0.1.0
git push origin v0.1.0
```
Binaries will appear on the [Releases page](https://github.com/Crank-Git/Hydrascale/releases).

## Test plan
- [ ] Merge and push `v0.1.0` tag
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Verify release page has linux/amd64 and linux/arm64 tar.gz + checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)