### PR TITLE
Feature/configurable infra and routes

### DIFF
--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -80,10 +80,15 @@ func loadConfig() (*config.Config, error) {
 }
 
 func newReconciler() *reconciler.Reconciler {
+	cfg, _ := loadConfig()
+	infraSubnet := "10.200.0.0/16"
+	if cfg != nil && cfg.InfraSubnet != "" {
+		infraSubnet = cfg.InfraSubnet
+	}
 	ns := namespaces.NewRealManager()
 	dm := daemon.NewRealManager()
 	rt := routing.NewRealManager()
-	return reconciler.New(configPath(), ns, dm, rt, 10*time.Second, nil)
+	return reconciler.New(configPath(), ns, dm, rt, 10*time.Second, nil, infraSubnet)
 }
 
 // --- Declarative commands ---
@@ -426,7 +431,7 @@ func serveCmd() *cobra.Command {
 			var ha *hostaccess.Manager
 			dnsMode := cfg.EffectiveHostDNSMode()
 			if dnsMode != "" {
-				ha = hostaccess.NewManager(dnsMode, "/etc/hosts")
+				ha = hostaccess.NewManager(dnsMode, "/etc/hosts", cfg.InfraSubnet)
 			}
 
 			r := reconciler.New(
@@ -436,6 +441,7 @@ func serveCmd() *cobra.Command {
 				routing.NewRealManager(),
 				interval,
 				ha,
+				cfg.InfraSubnet,
 			)
 
 			// Set up JSON event logging if configured

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -30,14 +30,14 @@ func newMockNS() *mockNS {
 	return &mockNS{namespaces: make(map[string]bool)}
 }
 
-func (m *mockNS) Create(tailnetID string) error {
+func (m *mockNS) Create(tailnetID string, infraSubnet string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.namespaces[m.GetName(tailnetID)] = true
 	return nil
 }
 
-func (m *mockNS) Delete(nsName string) error {
+func (m *mockNS) Delete(nsName string, infraSubnet string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.namespaces, nsName)
@@ -62,8 +62,8 @@ func (m *mockNS) GetTailnetID(nsName string) string {
 	return namespaces.GetTailnetFromNamespace(nsName)
 }
 
-func (m *mockNS) SetupVeth(nsName string, index int) error { return nil }
-func (m *mockNS) TeardownVeth(nsName string) error         { return nil }
+func (m *mockNS) SetupVeth(nsName string, index int, infraSubnet string) error { return nil }
+func (m *mockNS) TeardownVeth(nsName string, infraSubnet string) error         { return nil }
 
 type mockDaemon struct {
 	mu           sync.Mutex
@@ -113,8 +113,12 @@ type mockRouting struct{}
 func (m *mockRouting) PollStatus(nsName, socketPath string) ([]routing.Route, error) {
 	return nil, nil
 }
-func (m *mockRouting) SyncRoutes(nsName string, routes []routing.Route) error { return nil }
-func (m *mockRouting) ListRoutes(nsName string) ([]string, error)             { return nil, nil }
+func (m *mockRouting) SyncRoutes(nsName string, routes []routing.Route, infraSubnet string) error {
+	return nil
+}
+func (m *mockRouting) ListRoutes(nsName string, infraSubnet string) ([]string, error) {
+	return nil, nil
+}
 
 // --- Helpers ---
 
@@ -133,7 +137,7 @@ func writeTestConfig(t *testing.T, tailnets ...string) string {
 }
 
 func newTestReconciler(cfgPath string) *reconciler.Reconciler {
-	return reconciler.New(cfgPath, newMockNS(), newMockDaemon(), &mockRouting{}, 1*time.Second, nil)
+	return reconciler.New(cfgPath, newMockNS(), newMockDaemon(), &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
 }
 
 // startTestServer starts a Server on a temp socket and returns the server, client, and cleanup func.
@@ -380,7 +384,7 @@ func TestServerShutdownCleanup(t *testing.T) {
 // Verify ReconcileResponse.Message is populated on failure.
 func TestReconcileEndpointError(t *testing.T) {
 	// Use a non-existent config path so Reconcile() returns an error.
-	r := reconciler.New("/nonexistent/config.yaml", newMockNS(), newMockDaemon(), &mockRouting{}, time.Second, nil)
+	r := reconciler.New("/nonexistent/config.yaml", newMockNS(), newMockDaemon(), &mockRouting{}, time.Second, nil, "10.200.0.0/16")
 	socketPath := filepath.Join(t.TempDir(), "err-api.sock")
 	srv := NewServer(socketPath, r)
 	if err := srv.Start(); err != nil {
@@ -421,7 +425,7 @@ func TestDetailEndpoint_HappyPath(t *testing.T) {
 			"peer2": {HostName: "peer2", Online: false},
 		},
 	}
-	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil)
+	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
 	_, client, cleanup := startTestServer(t, r)
 	defer cleanup()
 
@@ -452,7 +456,7 @@ func TestDetailEndpoint_DaemonStarting(t *testing.T) {
 	md := newMockDaemon()
 	md.statusResult = nil
 	md.statusErr = nil
-	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil)
+	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
 	_, client, cleanup := startTestServer(t, r)
 	defer cleanup()
 
@@ -472,7 +476,7 @@ func TestDetailEndpoint_DaemonError(t *testing.T) {
 	cfgPath := writeTestConfig(t, "alpha")
 	md := newMockDaemon()
 	md.statusErr = fmt.Errorf("context deadline exceeded")
-	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil)
+	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
 	_, client, cleanup := startTestServer(t, r)
 	defer cleanup()
 
@@ -504,7 +508,7 @@ func TestDetailEndpoint_NoPeers(t *testing.T) {
 		Self: daemon.StatusNode{TailscaleIPs: []string{"100.64.1.1"}},
 		Peer: map[string]daemon.StatusNode{},
 	}
-	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil)
+	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
 	_, client, cleanup := startTestServer(t, r)
 	defer cleanup()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,8 +42,8 @@ type Mesh struct {
 
 // ReconcilerConfig holds reconciler-specific settings.
 type ReconcilerConfig struct {
-	Interval time.Duration `yaml:"-"`
-	RawInterval string    `yaml:"interval,omitempty"`
+	Interval    time.Duration `yaml:"-"`
+	RawInterval string        `yaml:"interval,omitempty"`
 }
 
 // ResolverConfig represents DNS resolver configuration.
@@ -54,15 +54,16 @@ type ResolverConfig struct {
 
 // Config represents the Hydrascale service configuration.
 type Config struct {
-	Version    int              `yaml:"version,omitempty"`
-	HostAccess bool             `yaml:"host_access,omitempty"`
-	ControlURL string           `yaml:"control_url,omitempty"`
-	Tailnets   []Tailnet        `yaml:"tailnets"`
-	Resolver   ResolverConfig   `yaml:"resolver"`
-	Reconciler ReconcilerConfig `yaml:"reconciler,omitempty"`
-	Mesh       Mesh             `yaml:"mesh,omitempty"`
-	EventLog   string           `yaml:"event_log,omitempty"`
-	HostDNS    HostDNSConfig    `yaml:"host_dns,omitempty"`
+	Version     int              `yaml:"version,omitempty"`
+	HostAccess  bool             `yaml:"host_access,omitempty"`
+	ControlURL  string           `yaml:"control_url,omitempty"`
+	Tailnets    []Tailnet        `yaml:"tailnets"`
+	Resolver    ResolverConfig   `yaml:"resolver"`
+	Reconciler  ReconcilerConfig `yaml:"reconciler,omitempty"`
+	Mesh        Mesh             `yaml:"mesh,omitempty"`
+	EventLog    string           `yaml:"event_log,omitempty"`
+	HostDNS     HostDNSConfig    `yaml:"host_dns,omitempty"`
+	InfraSubnet string           `yaml:"infra_subnet,omitempty"` // Default: 10.200.0.0/16
 }
 
 // TailnetHostAccess returns whether host access is enabled for a specific tailnet,
@@ -155,14 +156,32 @@ func LoadConfig(path string) (*Config, error) {
 		cfg.Reconciler.Interval = 10 * time.Second
 	}
 
+	// Validate and default infra_subnet
+	if cfg.InfraSubnet == "" {
+		cfg.InfraSubnet = "10.200.0.0/16"
+	} else {
+		ip, ipnet, err := net.ParseCIDR(cfg.InfraSubnet)
+		if err != nil {
+			return nil, fmt.Errorf("invalid infra_subnet %q: %w", cfg.InfraSubnet, err)
+		}
+		if ip.To4() == nil {
+			return nil, fmt.Errorf("infra_subnet must be an IPv4 CIDR, got %q", cfg.InfraSubnet)
+		}
+		ones, bits := ipnet.Mask.Size()
+		if bits != 32 || ones > 16 {
+			return nil, fmt.Errorf("infra_subnet %q is too small, must be at least /16", cfg.InfraSubnet)
+		}
+	}
+
 	return &cfg, nil
 }
 
 // DefaultConfig returns a default v2 configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		Version:  2,
-		Tailnets: []Tailnet{},
+		Version:     2,
+		InfraSubnet: "10.200.0.0/16",
+		Tailnets:    []Tailnet{},
 		Resolver: ResolverConfig{
 			Mode: "unified",
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -129,7 +129,7 @@ func StartDaemon(tailnetID string, namespaceName string) error {
 	// Setpgid detaches the process group; Pdeathsig ensures tailscaled
 	// is killed if hydrascale dies unexpectedly (e.g. SIGKILL).
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:  true,
+		Setpgid:   true,
 		Pdeathsig: syscall.SIGTERM,
 	}
 
@@ -364,4 +364,3 @@ func validatePID(pid int) bool {
 	}
 	return strings.Contains(string(data), "tailscaled")
 }
-

--- a/internal/hostaccess/hostaccess.go
+++ b/internal/hostaccess/hostaccess.go
@@ -9,23 +9,28 @@ import (
 
 // Manager coordinates host access features: routes, DNS, and namespace setup.
 type Manager struct {
-	mu        sync.Mutex
-	dnsMode   string // "hosts" or "resolved"
-	hostsPath string
-	resolved  *ResolvedManager
+	mu          sync.Mutex
+	dnsMode     string // "hosts" or "resolved"
+	hostsPath   string
+	infraSubnet string
+	resolved    *ResolvedManager
 
 	// Track which tailnets have been synced so teardown knows what to clean up
 	activeTailnets map[string]TailnetPeers
 }
 
 // NewManager creates a new host access Manager.
-func NewManager(dnsMode string, hostsPath string) *Manager {
+func NewManager(dnsMode string, hostsPath string, infraSubnet string) *Manager {
 	if hostsPath == "" {
 		hostsPath = "/etc/hosts"
+	}
+	if infraSubnet == "" {
+		infraSubnet = "10.200.0.0/16"
 	}
 	m := &Manager{
 		dnsMode:        dnsMode,
 		hostsPath:      hostsPath,
+		infraSubnet:    infraSubnet,
 		activeTailnets: make(map[string]TailnetPeers),
 	}
 	if dnsMode == "resolved" {
@@ -46,7 +51,7 @@ func (m *Manager) Sync(tailnetID string, status *daemon.TailscaleStatus, vethGW,
 	m.activeTailnets[tailnetID] = peers
 	m.mu.Unlock()
 
-	if err := SyncHostRoutes(peers); err != nil {
+	if err := SyncHostRoutes(peers, m.infraSubnet); err != nil {
 		log.Printf("host-access: route sync failed for %s: %v", tailnetID, err)
 	}
 
@@ -63,7 +68,7 @@ func (m *Manager) Teardown(tailnetID string) {
 	m.mu.Unlock()
 
 	if exists {
-		RemoveAllHostRoutes(peers.VethHost)
+		RemoveAllHostRoutes(peers.VethHost, m.infraSubnet)
 	}
 
 	m.syncDNS()
@@ -80,7 +85,7 @@ func (m *Manager) TeardownAll() {
 	m.mu.Unlock()
 
 	for _, peers := range tailnets {
-		RemoveAllHostRoutes(peers.VethHost)
+		RemoveAllHostRoutes(peers.VethHost, m.infraSubnet)
 	}
 
 	m.syncDNS()

--- a/internal/hostaccess/hostaccess.go
+++ b/internal/hostaccess/hostaccess.go
@@ -40,8 +40,8 @@ func NewManager(dnsMode string, hostsPath string, infraSubnet string) *Manager {
 }
 
 // Sync updates host routes and DNS for a tailnet's peers.
-func (m *Manager) Sync(tailnetID string, status *daemon.TailscaleStatus, vethGW, vethHost string) {
-	peers := ParsePeers(tailnetID, status, vethGW, vethHost)
+func (m *Manager) Sync(tailnetID string, status *daemon.TailscaleStatus, vethGW, vethHost, nsName string) {
+	peers := ParsePeers(tailnetID, status, vethGW, vethHost, nsName)
 
 	if len(peers.Peers) == 0 && status == nil {
 		return

--- a/internal/hostaccess/hostaccess_test.go
+++ b/internal/hostaccess/hostaccess_test.go
@@ -38,7 +38,7 @@ func TestSync_FullFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := NewManager("hosts", hostsPath)
+	m := NewManager("hosts", hostsPath, "10.200.0.0/16")
 	status := makeTestStatus()
 
 	m.Sync("havoc", status, "10.0.0.1", "veth0")
@@ -81,7 +81,7 @@ func TestSync_NilStatus(t *testing.T) {
 	}
 	info1, _ := os.Stat(hostsPath)
 
-	m := NewManager("hosts", hostsPath)
+	m := NewManager("hosts", hostsPath, "10.200.0.0/16")
 	m.Sync("havoc", nil, "10.0.0.1", "veth0")
 
 	info2, _ := os.Stat(hostsPath)
@@ -101,7 +101,7 @@ func TestSync_PartialFailure(t *testing.T) {
 	dir := t.TempDir()
 	hostsPath := filepath.Join(dir, "hosts")
 
-	m := NewManager("hosts", hostsPath)
+	m := NewManager("hosts", hostsPath, "10.200.0.0/16")
 	status := makeTestStatus()
 
 	// Routes will fail (no root), but should not block DNS update
@@ -127,7 +127,7 @@ func TestTeardown_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 	hostsPath := filepath.Join(dir, "hosts")
 
-	m := NewManager("hosts", hostsPath)
+	m := NewManager("hosts", hostsPath, "10.200.0.0/16")
 
 	// Should not panic
 	m.Teardown("nonexistent-tailnet")

--- a/internal/hostaccess/hostaccess_test.go
+++ b/internal/hostaccess/hostaccess_test.go
@@ -41,7 +41,7 @@ func TestSync_FullFlow(t *testing.T) {
 	m := NewManager("hosts", hostsPath, "10.200.0.0/16")
 	status := makeTestStatus()
 
-	m.Sync("havoc", status, "10.0.0.1", "veth0")
+	m.Sync("havoc", status, "10.0.0.1", "veth0", "ns-havoc")
 
 	got, err := os.ReadFile(hostsPath)
 	if err != nil {
@@ -82,7 +82,7 @@ func TestSync_NilStatus(t *testing.T) {
 	info1, _ := os.Stat(hostsPath)
 
 	m := NewManager("hosts", hostsPath, "10.200.0.0/16")
-	m.Sync("havoc", nil, "10.0.0.1", "veth0")
+	m.Sync("havoc", nil, "10.0.0.1", "veth0", "ns-havoc")
 
 	info2, _ := os.Stat(hostsPath)
 	if info2.ModTime() != info1.ModTime() {
@@ -105,7 +105,7 @@ func TestSync_PartialFailure(t *testing.T) {
 	status := makeTestStatus()
 
 	// Routes will fail (no root), but should not block DNS update
-	m.Sync("havoc", status, "10.0.0.1", "veth0")
+	m.Sync("havoc", status, "10.0.0.1", "veth0", "ns-havoc")
 
 	got, err := os.ReadFile(hostsPath)
 	if err != nil {

--- a/internal/hostaccess/peers.go
+++ b/internal/hostaccess/peers.go
@@ -20,18 +20,21 @@ type TailnetPeers struct {
 	Peers          []Peer
 	VethGateway    string
 	VethHost       string
+	NsName         string
 }
 
-func ParsePeers(tailnetID string, status *daemon.TailscaleStatus, vethGW, vethHost string) TailnetPeers {
+func ParsePeers(tailnetID string, status *daemon.TailscaleStatus, vethGW, vethHost, nsName string) TailnetPeers {
 	result := TailnetPeers{
 		TailnetID:   tailnetID,
 		VethGateway: vethGW,
 		VethHost:    vethHost,
+		NsName:      nsName,
 	}
 	if status == nil {
 		return result
 	}
 	result.MagicDNSSuffix = status.MagicDNSSuffix
+
 	for _, node := range status.Peer {
 		// Sanitize hostname: lowercase, replace spaces with dashes
 		hostname := strings.ToLower(node.HostName)

--- a/internal/hostaccess/peers_test.go
+++ b/internal/hostaccess/peers_test.go
@@ -28,7 +28,7 @@ func TestParsePeers_MultiplePeers(t *testing.T) {
 		},
 	})
 
-	result := ParsePeers("mynet", status, "10.0.0.1", "10.0.0.2")
+	result := ParsePeers("mynet", status, "10.0.0.1", "10.0.0.2", "ns-mynet")
 
 	if result.TailnetID != "mynet" {
 		t.Errorf("TailnetID = %q, want %q", result.TailnetID, "mynet")
@@ -76,7 +76,7 @@ func TestParsePeers_MultiplePeers(t *testing.T) {
 
 func TestParsePeers_EmptyPeerList(t *testing.T) {
 	status := makeStatus("example.ts.net", map[string]daemon.StatusNode{})
-	result := ParsePeers("mynet", status, "", "")
+	result := ParsePeers("mynet", status, "", "", "ns-mynet")
 	if len(result.Peers) != 0 {
 		t.Errorf("expected 0 peers, got %d", len(result.Peers))
 	}
@@ -93,7 +93,7 @@ func TestParsePeers_OfflinePeersIncluded(t *testing.T) {
 			Online:       false,
 		},
 	})
-	result := ParsePeers("net", status, "", "")
+	result := ParsePeers("net", status, "", "", "ns-net")
 	if len(result.Peers) != 1 {
 		t.Fatalf("expected 1 peer, got %d", len(result.Peers))
 	}
@@ -103,7 +103,7 @@ func TestParsePeers_OfflinePeersIncluded(t *testing.T) {
 }
 
 func TestParsePeers_NilStatus(t *testing.T) {
-	result := ParsePeers("mynet", nil, "gw", "host")
+	result := ParsePeers("mynet", nil, "gw", "host", "ns-mynet")
 	if result.TailnetID != "mynet" {
 		t.Errorf("TailnetID = %q, want %q", result.TailnetID, "mynet")
 	}
@@ -122,7 +122,7 @@ func TestParsePeers_MissingMagicDNSSuffix(t *testing.T) {
 	status := makeStatus("", map[string]daemon.StatusNode{
 		"a": {HostName: "Node", TailscaleIPs: []string{"100.64.0.5"}},
 	})
-	result := ParsePeers("net", status, "", "")
+	result := ParsePeers("net", status, "", "", "ns-net")
 	if result.MagicDNSSuffix != "" {
 		t.Errorf("expected empty MagicDNSSuffix, got %q", result.MagicDNSSuffix)
 	}
@@ -130,10 +130,10 @@ func TestParsePeers_MissingMagicDNSSuffix(t *testing.T) {
 
 func TestParsePeers_PeerWithNoIPs_Excluded(t *testing.T) {
 	status := makeStatus("", map[string]daemon.StatusNode{
-		"noip": {HostName: "NoIP", TailscaleIPs: []string{}},
+		"noip":  {HostName: "NoIP", TailscaleIPs: []string{}},
 		"hasip": {HostName: "HasIP", TailscaleIPs: []string{"100.64.0.9"}},
 	})
-	result := ParsePeers("net", status, "", "")
+	result := ParsePeers("net", status, "", "", "ns-net")
 	if len(result.Peers) != 1 {
 		t.Fatalf("expected 1 peer (no-IP excluded), got %d", len(result.Peers))
 	}
@@ -146,7 +146,7 @@ func TestParsePeers_InvalidIPSkipped(t *testing.T) {
 	status := makeStatus("", map[string]daemon.StatusNode{
 		"bad": {HostName: "Bad", TailscaleIPs: []string{"not-an-ip", "100.64.0.3"}},
 	})
-	result := ParsePeers("net", status, "", "")
+	result := ParsePeers("net", status, "", "", "ns-net")
 	if len(result.Peers) != 1 {
 		t.Fatalf("expected 1 peer, got %d", len(result.Peers))
 	}

--- a/internal/hostaccess/routes.go
+++ b/internal/hostaccess/routes.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	cgnatNet  *net.IPNet
-	tsV6Net   *net.IPNet
-	magicDNS  = "100.100.100.100"
+	cgnatNet *net.IPNet
+	tsV6Net  *net.IPNet
+	magicDNS = "100.100.100.100"
 )
 
 func init() {
@@ -20,28 +20,34 @@ func init() {
 	_, tsV6Net, _ = net.ParseCIDR("fd7a:115c:a1e0::/48")
 }
 
-// isCGNAT reports whether ip is in the Tailscale CGNAT range 100.64.0.0/10.
-func isCGNAT(ip string) bool {
-	parsed := net.ParseIP(ip)
-	if parsed == nil {
-		return false
+// isCGNAT reports whether dest is in the Tailscale CGNAT range 100.64.0.0/10.
+func isCGNAT(dest string) bool {
+	if ip := net.ParseIP(dest); ip != nil {
+		return cgnatNet.Contains(ip)
 	}
-	return cgnatNet.Contains(parsed)
+	if ip, _, err := net.ParseCIDR(dest); err == nil {
+		return cgnatNet.Contains(ip)
+	}
+	return false
 }
 
-// isTailscaleV6 reports whether ip is in fd7a:115c:a1e0::/48.
-func isTailscaleV6(ip string) bool {
-	parsed := net.ParseIP(ip)
-	if parsed == nil {
-		return false
+// isTailscaleV6 reports whether dest is in fd7a:115c:a1e0::/48.
+func isTailscaleV6(dest string) bool {
+	if ip := net.ParseIP(dest); ip != nil {
+		return tsV6Net.Contains(ip)
 	}
-	return tsV6Net.Contains(parsed)
+	if ip, _, err := net.ParseCIDR(dest); err == nil {
+		return tsV6Net.Contains(ip)
+	}
+	return false
 }
 
-// parseHostRoutes parses `ip route show` output and returns host routes
-// that are in the CGNAT range on vethDev, excluding the MagicDNS address.
-func parseHostRoutes(output string, vethDev string) []string {
+// parseHostRoutes parses `ip route show` output and returns route destinations
+// on vethDev, excluding MagicDNS and infra routes.
+func parseHostRoutes(output string, vethDev string, infraSubnet string) []string {
 	var routes []string
+	_, infraNet, _ := net.ParseCIDR(infraSubnet)
+
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -55,26 +61,30 @@ func parseHostRoutes(output string, vethDev string) []string {
 		if dest == "default" {
 			continue
 		}
-		// Exclude MagicDNS infrastructure address
 		if dest == magicDNS {
 			continue
 		}
-		// Must be a host route (bare IP, no prefix) or /32
-		ip := strings.TrimSuffix(dest, "/32")
-		if !isCGNAT(ip) {
-			continue
+		if infraNet != nil {
+			if destIP, _, err := net.ParseCIDR(dest); err == nil {
+				if infraNet.Contains(destIP) {
+					continue
+				}
+			} else if destIP := net.ParseIP(dest); destIP != nil {
+				if infraNet.Contains(destIP) {
+					continue
+				}
+			}
 		}
-		// Must be on the expected veth device
 		if vethDev != "" && !strings.Contains(line, "dev "+vethDev) {
 			continue
 		}
-		routes = append(routes, ip)
+		routes = append(routes, dest)
 	}
 	return routes
 }
 
-// parseHostRoutesV6 parses `ip -6 route show` output and returns host routes
-// in the Tailscale IPv6 range on vethDev.
+// parseHostRoutesV6 parses `ip -6 route show` output and returns route destinations
+// on vethDev, excluding default routes.
 func parseHostRoutesV6(output string, vethDev string) []string {
 	var routes []string
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
@@ -90,20 +100,62 @@ func parseHostRoutesV6(output string, vethDev string) []string {
 		if dest == "default" || dest == "::/0" {
 			continue
 		}
-		ip := strings.TrimSuffix(dest, "/128")
-		if !isTailscaleV6(ip) {
-			continue
-		}
 		if vethDev != "" && !strings.Contains(line, "dev "+vethDev) {
 			continue
 		}
-		routes = append(routes, ip)
+		routes = append(routes, dest)
 	}
 	return routes
 }
 
-// desiredRoutes extracts the v4 and v6 peer IPs from a TailnetPeers set.
-func desiredRoutes(peers TailnetPeers) (v4, v6 []string) {
+// parseTableRoutes parses `ip route show table N` output and returns only
+// subnet route destinations. It excludes default routes, infra subnet,
+// MagicDNS, and Tailscale CGNAT/v6 ranges (peer IPs and catch-alls that
+// are already handled by the peer route sync or veth setup).
+func parseTableRoutes(output string, infraSubnet string) []string {
+	var routes []string
+	_, infraNet, _ := net.ParseCIDR(infraSubnet)
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		dest := fields[0]
+		if dest == "default" || dest == "0.0.0.0/0" || dest == "::/0" {
+			continue
+		}
+		if dest == magicDNS {
+			continue
+		}
+		if isCGNAT(dest) {
+			continue
+		}
+		if isTailscaleV6(dest) {
+			continue
+		}
+		if infraNet != nil {
+			if destIP, _, err := net.ParseCIDR(dest); err == nil {
+				if infraNet.Contains(destIP) {
+					continue
+				}
+			} else if destIP := net.ParseIP(dest); destIP != nil {
+				if infraNet.Contains(destIP) {
+					continue
+				}
+			}
+		}
+		routes = append(routes, dest)
+	}
+	return routes
+}
+
+// desiredPeerRoutes extracts the v4 and v6 peer IPs from a TailnetPeers set.
+func desiredPeerRoutes(peers TailnetPeers) (v4, v6 []string) {
 	for _, p := range peers.Peers {
 		if p.IPv4 != "" {
 			v4 = append(v4, p.IPv4)
@@ -115,7 +167,7 @@ func desiredRoutes(peers TailnetPeers) (v4, v6 []string) {
 	return v4, v6
 }
 
-// diffRoutes returns the IPs to add (in desired but not actual) and to remove
+// diffRoutes returns the destinations to add (in desired but not actual) and to remove
 // (in actual but not desired).
 func diffRoutes(desired, actual []string) (toAdd, toRemove []string) {
 	desiredSet := make(map[string]bool, len(desired))
@@ -140,11 +192,68 @@ func diffRoutes(desired, actual []string) (toAdd, toRemove []string) {
 	return toAdd, toRemove
 }
 
+// listNsTableRoutes reads routing table 52 from inside a namespace and returns
+// the route destinations (subnet routes accepted by tailscaled via --accept-routes).
+func listNsTableRoutes(nsName string, infraSubnet string) ([]string, error) {
+	out, err := exec.Command("ip", "netns", "exec", nsName, "ip", "route", "show", "table", "52").Output()
+	if err != nil {
+		return nil, fmt.Errorf("ip netns exec %s ip route show table 52: %w", nsName, err)
+	}
+	return parseTableRoutes(string(out), infraSubnet), nil
+}
+
+// listNsTableRoutesV6 reads IPv6 routing table 52 from inside a namespace,
+// returning only non-Tailscale subnet routes.
+func listNsTableRoutesV6(nsName string) ([]string, error) {
+	out, err := exec.Command("ip", "netns", "exec", nsName, "ip", "-6", "route", "show", "table", "52").Output()
+	if err != nil {
+		return nil, fmt.Errorf("ip netns exec %s ip -6 route show table 52: %w", nsName, err)
+	}
+	var routes []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		dest := fields[0]
+		if dest == "default" || dest == "::/0" {
+			continue
+		}
+		if isTailscaleV6(dest) {
+			continue
+		}
+		routes = append(routes, dest)
+	}
+	return routes, nil
+}
+
 // SyncHostRoutes synchronises host routing table entries for all peers in the
-// TailnetPeers set, routing their IPs via the veth gateway.
-func SyncHostRoutes(peers TailnetPeers) error {
+// TailnetPeers set and for any accepted subnet routes from table 52 in the namespace.
+// Both desired sets are merged before diffing so that peer routes don't remove
+// subnet routes (or vice versa).
+func SyncHostRoutes(peers TailnetPeers, infraSubnet string) error {
 	vethDev := peers.VethHost
 	gw := peers.VethGateway
+
+	// Build the combined desired set: peer IPs + accepted routes from table 52
+	wantV4, wantV6 := desiredPeerRoutes(peers)
+
+	if peers.NsName != "" {
+		nsV4, err := listNsTableRoutes(peers.NsName, infraSubnet)
+		if err != nil {
+			log.Printf("hostaccess: failed to read table 52 v4 routes from %s: %v", peers.NsName, err)
+		}
+		nsV6, err := listNsTableRoutesV6(peers.NsName)
+		if err != nil {
+			log.Printf("hostaccess: failed to read table 52 v6 routes from %s: %v", peers.NsName, err)
+		}
+		wantV4 = mergeRoutes(wantV4, nsV4)
+		wantV6 = mergeRoutes(wantV6, nsV6)
+	}
 
 	// Gather current host routes
 	v4Out, err := exec.Command("ip", "route", "show").Output()
@@ -156,10 +265,8 @@ func SyncHostRoutes(peers TailnetPeers) error {
 		return fmt.Errorf("ip -6 route show: %w", err)
 	}
 
-	actualV4 := parseHostRoutes(string(v4Out), vethDev)
+	actualV4 := parseHostRoutes(string(v4Out), vethDev, infraSubnet)
 	actualV6 := parseHostRoutesV6(string(v6Out), vethDev)
-
-	wantV4, wantV6 := desiredRoutes(peers)
 
 	addV4, delV4 := diffRoutes(wantV4, actualV4)
 	addV6, delV6 := diffRoutes(wantV6, actualV6)
@@ -182,12 +289,11 @@ func SyncHostRoutes(peers TailnetPeers) error {
 		}
 	}
 	for _, ip := range addV6 {
-		// IPv6 routes use dev-only (no IPv4 gateway); the kernel resolves next-hop via NDP
 		args := []string{"-6", "route", "replace", ip, "dev", vethDev}
 		if out, e := exec.Command("ip", args...).CombinedOutput(); e != nil {
 			errs = append(errs, fmt.Errorf("ip -6 route replace %s: %w (%s)", ip, e, out))
 		} else {
-			log.Printf("hostaccess: added v6 route %s via %s dev %s", ip, gw, vethDev)
+			log.Printf("hostaccess: added v6 route %s dev %s", ip, vethDev)
 		}
 	}
 	for _, ip := range delV6 {
@@ -201,11 +307,30 @@ func SyncHostRoutes(peers TailnetPeers) error {
 	return errors.Join(errs...)
 }
 
-// RemoveAllHostRoutes removes all CGNAT and Tailscale v6 host routes on vethDev.
-func RemoveAllHostRoutes(vethDev string) {
+// mergeRoutes merges two route lists, deduplicating by destination.
+func mergeRoutes(a, b []string) []string {
+	seen := make(map[string]bool, len(a)+len(b))
+	var result []string
+	for _, r := range a {
+		if !seen[r] {
+			seen[r] = true
+			result = append(result, r)
+		}
+	}
+	for _, r := range b {
+		if !seen[r] {
+			seen[r] = true
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// RemoveAllHostRoutes removes all host routes on vethDev (excluding MagicDNS and infra).
+func RemoveAllHostRoutes(vethDev string, infraSubnet string) {
 	v4Out, err := exec.Command("ip", "route", "show").Output()
 	if err == nil {
-		for _, ip := range parseHostRoutes(string(v4Out), vethDev) {
+		for _, ip := range parseHostRoutes(string(v4Out), vethDev, infraSubnet) {
 			if out, e := exec.Command("ip", "route", "del", ip).CombinedOutput(); e != nil {
 				log.Printf("hostaccess: remove route %s: %v (%s)", ip, e, out)
 			}

--- a/internal/hostaccess/routes_test.go
+++ b/internal/hostaccess/routes_test.go
@@ -7,21 +7,21 @@ import (
 
 func TestParseHostRoutes(t *testing.T) {
 	const vethDev = "vh123456"
+	const infraSubnet = "10.200.0.0/16"
 	input := `100.64.0.1 dev vh123456 scope link
 100.64.0.2 dev vh123456 scope link
 100.100.100.100 via 10.200.1.2 dev vh123456
 10.0.0.1 dev eth0 scope link
 100.64.0.3 dev eth0 scope link
+192.168.1.0/24 via 10.200.1.2 dev vh123456
 `
-	got := parseHostRoutes(input, vethDev)
-	// Expect 100.64.0.1 and 100.64.0.2 — 100.100.100.100 excluded, 10.0.0.1 not CGNAT,
-	// 100.64.0.3 on wrong device
-	want := []string{"100.64.0.1", "100.64.0.2"}
+	got := parseHostRoutes(input, vethDev, infraSubnet)
+	want := []string{"100.64.0.1", "100.64.0.2", "192.168.1.0/24"}
+	sort.Strings(got)
+	sort.Strings(want)
 	if len(got) != len(want) {
 		t.Fatalf("parseHostRoutes: got %v, want %v", got, want)
 	}
-	sort.Strings(got)
-	sort.Strings(want)
 	for i := range want {
 		if got[i] != want[i] {
 			t.Errorf("parseHostRoutes[%d]: got %q, want %q", i, got[i], want[i])
@@ -31,10 +31,11 @@ func TestParseHostRoutes(t *testing.T) {
 
 func TestParseHostRoutes_ExcludesMagicDNS(t *testing.T) {
 	const vethDev = "vh123456"
+	const infraSubnet = "10.200.0.0/16"
 	input := `100.100.100.100 via 10.200.1.2 dev vh123456
 100.64.1.1 dev vh123456 scope link
 `
-	got := parseHostRoutes(input, vethDev)
+	got := parseHostRoutes(input, vethDev, infraSubnet)
 	for _, ip := range got {
 		if ip == "100.100.100.100" {
 			t.Errorf("parseHostRoutes should exclude 100.100.100.100, but found it in %v", got)
@@ -42,6 +43,33 @@ func TestParseHostRoutes_ExcludesMagicDNS(t *testing.T) {
 	}
 	if len(got) != 1 || got[0] != "100.64.1.1" {
 		t.Errorf("parseHostRoutes: got %v, want [100.64.1.1]", got)
+	}
+}
+
+func TestParseTableRoutes(t *testing.T) {
+	const infraSubnet = "10.200.0.0/16"
+	input := `10.0.0.0/8 via 100.64.0.1 dev tailscale0
+172.16.0.0/12 via 100.64.0.1 dev tailscale0
+192.168.1.0/24 via 100.64.0.1 dev tailscale0
+default via 100.64.0.1 dev tailscale0
+10.200.3.0/30 dev vnabc proto kernel scope link
+100.64.0.5 dev tailscale0
+100.100.100.100 dev tailscale0
+fd7a:115c:a1e0::1 dev tailscale0
+fd7a:115c:a1e0::/48 dev tailscale0
+fd7a:115c:a1e0::53 dev tailscale0
+`
+	got := parseTableRoutes(input, infraSubnet)
+	want := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.1.0/24"}
+	sort.Strings(got)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("parseTableRoutes: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("parseTableRoutes[%d]: got %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 
@@ -54,7 +82,7 @@ func TestDesiredRoutes(t *testing.T) {
 			{Hostname: "delta"},
 		},
 	}
-	v4, v6 := desiredRoutes(peers)
+	v4, v6 := desiredPeerRoutes(peers)
 
 	wantV4 := []string{"100.64.0.1", "100.64.0.2"}
 	wantV6 := []string{"fd7a:115c:a1e0::1", "fd7a:115c:a1e0::3"}

--- a/internal/namespaces/ns.go
+++ b/internal/namespaces/ns.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,13 +14,13 @@ import (
 
 // Manager defines the interface for network namespace operations.
 type Manager interface {
-	Create(tailnetID string) error
-	Delete(nsName string) error
+	Create(tailnetID string, infraSubnet string) error
+	Delete(nsName string, infraSubnet string) error
 	List() ([]string, error)
 	GetName(tailnetID string) string
 	GetTailnetID(nsName string) string
-	SetupVeth(nsName string, index int) error
-	TeardownVeth(nsName string) error
+	SetupVeth(nsName string, index int, infraSubnet string) error
+	TeardownVeth(nsName string, infraSubnet string) error
 }
 
 // RealManager implements Manager using real system calls.
@@ -41,23 +42,23 @@ func (m *RealManager) GetTailnetID(nsName string) string {
 }
 
 // Create creates a new network namespace for the given tailnet ID.
-func (m *RealManager) Create(tailnetID string) error {
-	return CreateNamespace(tailnetID)
+func (m *RealManager) Create(tailnetID string, infraSubnet string) error {
+	return CreateNamespace(tailnetID, infraSubnet)
 }
 
 // Delete deletes the network namespace with the given name.
-func (m *RealManager) Delete(nsName string) error {
-	return DeleteNamespace(nsName)
+func (m *RealManager) Delete(nsName string, infraSubnet string) error {
+	return DeleteNamespace(nsName, infraSubnet)
 }
 
 // SetupVeth creates a veth pair between host and namespace for DNS routing.
-func (m *RealManager) SetupVeth(nsName string, index int) error {
-	return SetupVeth(nsName, index)
+func (m *RealManager) SetupVeth(nsName string, index int, infraSubnet string) error {
+	return SetupVeth(nsName, index, infraSubnet)
 }
 
 // TeardownVeth removes the veth pair for a namespace.
-func (m *RealManager) TeardownVeth(nsName string) error {
-	return TeardownVeth(nsName)
+func (m *RealManager) TeardownVeth(nsName string, infraSubnet string) error {
+	return TeardownVeth(nsName, infraSubnet)
 }
 
 // List returns a list of all Hydrascale network namespaces.
@@ -73,7 +74,7 @@ func GetNamespaceName(tailnetID string) string {
 
 // CreateNamespace creates a new network namespace for the given tailnet ID.
 // After creating the namespace, it sets up a veth pair for DNS routing.
-func CreateNamespace(tailnetID string) error {
+func CreateNamespace(tailnetID string, infraSubnet string) error {
 	namespaceName := GetNamespaceName(tailnetID)
 
 	cmd := exec.Command("ip", "netns", "add", namespaceName)
@@ -86,7 +87,7 @@ func CreateNamespace(tailnetID string) error {
 
 	// Set up veth pair for DNS routing
 	index := VethIndex(namespaceName)
-	if err := SetupVeth(namespaceName, index); err != nil {
+	if err := SetupVeth(namespaceName, index, infraSubnet); err != nil {
 		// Best effort cleanup: delete the namespace if veth setup fails
 		_ = exec.Command("ip", "netns", "del", namespaceName).Run()
 		return fmt.Errorf("failed to setup veth for namespace %q: %v", namespaceName, err)
@@ -97,9 +98,9 @@ func CreateNamespace(tailnetID string) error {
 
 // DeleteNamespace deletes the network namespace with the given name.
 // Tears down the veth pair before deleting the namespace.
-func DeleteNamespace(namespaceName string) error {
+func DeleteNamespace(namespaceName string, infraSubnet string) error {
 	// Tear down veth pair first (best effort - namespace deletion will clean up anyway)
-	if err := TeardownVeth(namespaceName); err != nil {
+	if err := TeardownVeth(namespaceName, infraSubnet); err != nil {
 		log.Printf("Warning: veth teardown for %s: %v", namespaceName, err)
 	}
 
@@ -153,7 +154,7 @@ func VethIndex(nsName string) int {
 	h := sha256.Sum256([]byte(nsName))
 	v := int(binary.BigEndian.Uint32(h[:4]))
 	// Map to 1-254 range (avoid 0 and 255)
-	return (v%254) + 1
+	return (v % 254) + 1
 }
 
 // VethNames returns a pair of interface names (host, namespace) that fit
@@ -165,15 +166,40 @@ func VethNames(nsName string) (host, ns string) {
 	return "vh" + tag, "vn" + tag
 }
 
+// VethIPs calculates the IPs for a veth pair given an infra subnet and an index.
+func VethIPs(infraSubnet string, index int) (hostIP, nsIP, hostGW, nsGW string, err error) {
+	_, ipnet, err := net.ParseCIDR(infraSubnet)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	// Use the index to pick a /30 subnet within the infraSubnet
+	// index is 1-based.
+	// 10.200.0.0/16 -> 10.200.0.0/30 (idx 1), 10.200.0.4/30 (idx 2), etc.
+	base := binary.BigEndian.Uint32(ipnet.IP.To4())
+	offset := uint32(index-1) * 4
+
+	uHostIP := base + offset + 1
+	uNsIP := base + offset + 2
+
+	ip1 := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip1, uHostIP)
+	ip2 := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip2, uNsIP)
+
+	return ip1.String() + "/30", ip2.String() + "/30", ip1.String(), ip2.String(), nil
+}
+
 // SetupVeth creates a veth pair between host and namespace for DNS routing.
-// Host side: vh<hash> with IP 10.200.N.1/30
-// Namespace side: vn<hash> with IP 10.200.N.2/30
-// Adds host route: 100.100.100.100 via 10.200.N.2 dev vh<hash>
-func SetupVeth(nsName string, index int) error {
+// Host side: vh<hash> with IP from infraSubnet
+// Namespace side: vn<hash> with IP from infraSubnet
+// Adds host route: 100.100.100.100 via namespace side dev vh<hash>
+func SetupVeth(nsName string, index int, infraSubnet string) error {
 	hostVeth, nsVeth := VethNames(nsName)
-	hostIP := fmt.Sprintf("10.200.%d.1/30", index)
-	nsIP := fmt.Sprintf("10.200.%d.2/30", index)
-	nsGW := fmt.Sprintf("10.200.%d.2", index)
+	hostIP, nsIP, hostGW, nsGW, err := VethIPs(infraSubnet, index)
+	if err != nil {
+		return err
+	}
 
 	// Create veth pair
 	cmd := exec.Command("ip", "link", "add", hostVeth, "type", "veth", "peer", "name", nsVeth)
@@ -212,7 +238,6 @@ func SetupVeth(nsName string, index int) error {
 	}
 
 	// Add default route inside namespace so tailscaled can reach the internet
-	hostGW := fmt.Sprintf("10.200.%d.1", index)
 	cmd = exec.Command("ip", "netns", "exec", nsName, "ip", "route", "add", "default", "via", hostGW, "dev", nsVeth)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to add default route in namespace %s: %v (%s)", nsName, err, out)
@@ -253,29 +278,30 @@ func SetupVeth(nsName string, index int) error {
 		return fmt.Errorf("failed to add route for 100.100.100.100 via %s: %v (%s)", nsGW, err, out)
 	}
 
-	log.Printf("Set up veth pair for namespace %s (10.200.%d.0/30)", nsName, index)
+	log.Printf("Set up veth pair for namespace %s with IPs from %s", nsName, infraSubnet)
 	return nil
 }
 
 // TeardownVeth removes the veth pair for a namespace.
 // Deleting the host side automatically removes the peer.
-func TeardownVeth(nsName string) error {
+func TeardownVeth(nsName string, infraSubnet string) error {
 	hostVeth, _ := VethNames(nsName)
 
 	// Remove iptables rules (best effort)
 	index := VethIndex(nsName)
-	nsIP := fmt.Sprintf("10.200.%d.2/30", index)
-	delFwd1 := exec.Command("iptables", "-D", "FORWARD", "-i", hostVeth, "-j", "ACCEPT")
-	_ = delFwd1.Run()
-	delFwd2 := exec.Command("iptables", "-D", "FORWARD", "-o", hostVeth, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT")
-	_ = delFwd2.Run()
-	delNat := exec.Command("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", nsIP, "-j", "MASQUERADE")
-	_ = delNat.Run()
+	_, nsIP, _, nsGW, err := VethIPs(infraSubnet, index)
+	if err == nil {
+		delFwd1 := exec.Command("iptables", "-D", "FORWARD", "-i", hostVeth, "-j", "ACCEPT")
+		_ = delFwd1.Run()
+		delFwd2 := exec.Command("iptables", "-D", "FORWARD", "-o", hostVeth, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT")
+		_ = delFwd2.Run()
+		delNat := exec.Command("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", nsIP, "-j", "MASQUERADE")
+		_ = delNat.Run()
 
-	// Remove the host route first (best effort)
-	nsGW := fmt.Sprintf("10.200.%d.2", index)
-	delRoute := exec.Command("ip", "route", "del", "100.100.100.100", "via", nsGW, "dev", hostVeth)
-	_ = delRoute.Run() // ignore error if route doesn't exist
+		// Remove the host route first (best effort)
+		delRoute := exec.Command("ip", "route", "del", "100.100.100.100", "via", nsGW, "dev", hostVeth)
+		_ = delRoute.Run() // ignore error if route doesn't exist
+	}
 
 	// Delete the veth pair (deleting one end removes both)
 	cmd := exec.Command("ip", "link", "del", hostVeth)
@@ -292,13 +318,16 @@ func TeardownVeth(nsName string) error {
 // - DNS DNAT on veth so MagicDNS queries from host reach 100.100.100.100
 // - /etc/netns/NAME/resolv.conf for MagicDNS inside the namespace
 // All rules are idempotent (check before insert).
-func SetupHostAccess(nsName string, index int) error {
+func SetupHostAccess(nsName string, index int, infraSubnet string) error {
 	_, nsVeth := VethNames(nsName)
-	nsIP := fmt.Sprintf("10.200.%d.0/30", index)
+	_, nsIPRange, _, _, err := VethIPs(infraSubnet, index)
+	if err != nil {
+		return err
+	}
 
 	// Masquerade on tailscale0
-	if exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-C", "POSTROUTING", "-s", nsIP, "-o", "tailscale0", "-j", "MASQUERADE").Run() != nil {
-		cmd := exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "POSTROUTING", "-s", nsIP, "-o", "tailscale0", "-j", "MASQUERADE")
+	if exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-C", "POSTROUTING", "-s", nsIPRange, "-o", "tailscale0", "-j", "MASQUERADE").Run() != nil {
+		cmd := exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "POSTROUTING", "-s", nsIPRange, "-o", "tailscale0", "-j", "MASQUERADE")
 		if out, err := cmd.CombinedOutput(); err != nil {
 			log.Printf("host-access: failed to add tailscale0 masquerade in %s: %v (%s)", nsName, err, out)
 		}
@@ -336,11 +365,15 @@ func SetupHostAccess(nsName string, index int) error {
 }
 
 // TeardownHostAccess removes namespace-side host access iptables rules and resolv.conf.
-func TeardownHostAccess(nsName string, index int) {
+func TeardownHostAccess(nsName string, index int, infraSubnet string) {
 	_, nsVeth := VethNames(nsName)
-	nsIP := fmt.Sprintf("10.200.%d.0/30", index)
+	_, nsIPRange, _, _, err := VethIPs(infraSubnet, index)
+	if err != nil {
+		log.Printf("host-access: failed to get veth IPs for teardown: %v", err)
+		return
+	}
 
-	exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-D", "POSTROUTING", "-s", nsIP, "-o", "tailscale0", "-j", "MASQUERADE").Run()
+	exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-D", "POSTROUTING", "-s", nsIPRange, "-o", "tailscale0", "-j", "MASQUERADE").Run()
 	exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-D", "PREROUTING", "-i", nsVeth, "-p", "udp", "--dport", "53", "-j", "DNAT", "--to-destination", "100.100.100.100:53").Run()
 	exec.Command("ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-D", "PREROUTING", "-i", nsVeth, "-p", "tcp", "--dport", "53", "-j", "DNAT", "--to-destination", "100.100.100.100:53").Run()
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -27,13 +27,13 @@ import (
 type ActionType string
 
 const (
-	ActionCreateNS    ActionType = "create_namespace"
-	ActionDeleteNS    ActionType = "delete_namespace"
-	ActionStartDaemon ActionType = "start_daemon"
-	ActionStopDaemon  ActionType = "stop_daemon"
-	ActionSyncRoutes      ActionType = "sync_routes"
-	ActionSyncHostAccess  ActionType = "sync_host_access"
-	ActionAuthDaemon      ActionType = "auth_daemon"
+	ActionCreateNS       ActionType = "create_namespace"
+	ActionDeleteNS       ActionType = "delete_namespace"
+	ActionStartDaemon    ActionType = "start_daemon"
+	ActionStopDaemon     ActionType = "stop_daemon"
+	ActionSyncRoutes     ActionType = "sync_routes"
+	ActionSyncHostAccess ActionType = "sync_host_access"
+	ActionAuthDaemon     ActionType = "auth_daemon"
 )
 
 // MaxFailures is the number of consecutive failures before a tailnet enters error state.
@@ -74,12 +74,13 @@ type Event struct {
 
 // Reconciler drives actual state toward desired state.
 type Reconciler struct {
-	configPath string
-	ns         namespaces.Manager
-	dm         daemon.Manager
-	rt         routing.Manager
-	ha         *hostaccess.Manager
-	interval   time.Duration
+	configPath  string
+	ns          namespaces.Manager
+	dm          daemon.Manager
+	rt          routing.Manager
+	ha          *hostaccess.Manager
+	interval    time.Duration
+	infraSubnet string
 
 	mu            sync.Mutex
 	failureCounts map[string]int    // tailnetID -> consecutive failure count
@@ -93,7 +94,10 @@ type Reconciler struct {
 }
 
 // New creates a new Reconciler with the given dependencies.
-func New(configPath string, ns namespaces.Manager, dm daemon.Manager, rt routing.Manager, interval time.Duration, ha *hostaccess.Manager) *Reconciler {
+func New(configPath string, ns namespaces.Manager, dm daemon.Manager, rt routing.Manager, interval time.Duration, ha *hostaccess.Manager, infraSubnet string) *Reconciler {
+	if infraSubnet == "" {
+		infraSubnet = "10.200.0.0/16"
+	}
 	return &Reconciler{
 		configPath:    configPath,
 		ns:            ns,
@@ -101,6 +105,7 @@ func New(configPath string, ns namespaces.Manager, dm daemon.Manager, rt routing
 		rt:            rt,
 		ha:            ha,
 		interval:      interval,
+		infraSubnet:   infraSubnet,
 		failureCounts: make(map[string]int),
 		errorStates:   make(map[string]bool),
 		pausedStates:  make(map[string]bool),
@@ -264,20 +269,20 @@ func (r *Reconciler) Apply(actions []Action) {
 func (r *Reconciler) executeAction(action Action) error {
 	switch action.Type {
 	case ActionCreateNS:
-		if err := r.ns.Create(action.TailnetID); err != nil {
+		if err := r.ns.Create(action.TailnetID, r.infraSubnet); err != nil {
 			return err
 		}
 		// Set up host access iptables if enabled for this tailnet
 		if cfg, err := config.LoadConfig(r.configPath); err == nil && cfg.TailnetHostAccess(action.TailnetID) {
 			nsName := r.ns.GetName(action.TailnetID)
 			index := namespaces.VethIndex(nsName)
-			if err := namespaces.SetupHostAccess(nsName, index); err != nil {
+			if err := namespaces.SetupHostAccess(nsName, index, r.infraSubnet); err != nil {
 				log.Printf("host-access: setup failed for %s: %v", nsName, err)
 			}
 		}
 		return nil
 	case ActionDeleteNS:
-		return r.ns.Delete(action.NsName)
+		return r.ns.Delete(action.NsName, r.infraSubnet)
 	case ActionStartDaemon:
 		return r.dm.Start(action.TailnetID, action.NsName)
 	case ActionStopDaemon:
@@ -290,7 +295,7 @@ func (r *Reconciler) executeAction(action Action) error {
 		if err != nil {
 			return err
 		}
-		return r.rt.SyncRoutes(action.NsName, routes)
+		return r.rt.SyncRoutes(action.NsName, routes, r.infraSubnet)
 	case ActionSyncHostAccess:
 		if r.ha == nil {
 			return nil
@@ -298,12 +303,15 @@ func (r *Reconciler) executeAction(action Action) error {
 		nsName := r.ns.GetName(action.TailnetID)
 		index := namespaces.VethIndex(nsName)
 		// Ensure namespace-side iptables are set up (idempotent — safe every cycle)
-		namespaces.SetupHostAccess(nsName, index)
+		namespaces.SetupHostAccess(nsName, index, r.infraSubnet)
 		status, err := r.dm.GetStatus(context.Background(), nsName, action.TailnetID)
 		if err != nil {
 			return fmt.Errorf("host-access: failed to get status for %s: %w", action.TailnetID, err)
 		}
-		vethGW := fmt.Sprintf("10.200.%d.2", index)
+		_, _, _, vethGW, err := namespaces.VethIPs(r.infraSubnet, index)
+		if err != nil {
+			return fmt.Errorf("host-access: failed to get veth IPs: %w", err)
+		}
 		vethHost, _ := namespaces.VethNames(nsName)
 		r.ha.Sync(action.TailnetID, status, vethGW, vethHost)
 		return nil

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -313,7 +313,7 @@ func (r *Reconciler) executeAction(action Action) error {
 			return fmt.Errorf("host-access: failed to get veth IPs: %w", err)
 		}
 		vethHost, _ := namespaces.VethNames(nsName)
-		r.ha.Sync(action.TailnetID, status, vethGW, vethHost)
+		r.ha.Sync(action.TailnetID, status, vethGW, vethHost, nsName)
 		return nil
 	default:
 		return fmt.Errorf("unknown action type: %s", action.Type)

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -30,7 +30,7 @@ func newMockNS() *mockNS {
 	return &mockNS{namespaces: make(map[string]bool)}
 }
 
-func (m *mockNS) Create(tailnetID string) error {
+func (m *mockNS) Create(tailnetID string, infraSubnet string) error {
 	if m.createErr != nil {
 		return m.createErr
 	}
@@ -38,7 +38,7 @@ func (m *mockNS) Create(tailnetID string) error {
 	return nil
 }
 
-func (m *mockNS) Delete(nsName string) error {
+func (m *mockNS) Delete(nsName string, infraSubnet string) error {
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
@@ -65,11 +65,11 @@ func (m *mockNS) GetTailnetID(nsName string) string {
 	return namespaces.GetTailnetFromNamespace(nsName)
 }
 
-func (m *mockNS) SetupVeth(nsName string, index int) error {
+func (m *mockNS) SetupVeth(nsName string, index int, infraSubnet string) error {
 	return nil
 }
 
-func (m *mockNS) TeardownVeth(nsName string) error {
+func (m *mockNS) TeardownVeth(nsName string, infraSubnet string) error {
 	return nil
 }
 
@@ -152,7 +152,7 @@ func (m *mockRouting) PollStatus(nsName, socketPath string) ([]routing.Route, er
 	return m.routes[nsName], nil
 }
 
-func (m *mockRouting) SyncRoutes(nsName string, routes []routing.Route) error {
+func (m *mockRouting) SyncRoutes(nsName string, routes []routing.Route, infraSubnet string) error {
 	if m.syncErr != nil {
 		return m.syncErr
 	}
@@ -160,7 +160,7 @@ func (m *mockRouting) SyncRoutes(nsName string, routes []routing.Route) error {
 	return nil
 }
 
-func (m *mockRouting) ListRoutes(nsName string) ([]string, error) {
+func (m *mockRouting) ListRoutes(nsName string, infraSubnet string) ([]string, error) {
 	if m.listErr != nil {
 		return nil, m.listErr
 	}
@@ -185,7 +185,7 @@ func writeTestConfig(t *testing.T, tailnets ...string) string {
 }
 
 func newTestReconciler(cfgPath string, ns *mockNS, dm *mockDaemon, rt *mockRouting) *Reconciler {
-	return New(cfgPath, ns, dm, rt, 1*time.Second, nil)
+	return New(cfgPath, ns, dm, rt, 1*time.Second, nil, "10.200.0.0/16")
 }
 
 // --- Tests ---

--- a/internal/routing/routes.go
+++ b/internal/routing/routes.go
@@ -14,8 +14,8 @@ import (
 // Manager defines the interface for route management operations.
 type Manager interface {
 	PollStatus(nsName, socketPath string) ([]Route, error)
-	SyncRoutes(nsName string, routes []Route) error
-	ListRoutes(nsName string) ([]string, error)
+	SyncRoutes(nsName string, routes []Route, infraSubnet string) error
+	ListRoutes(nsName string, infraSubnet string) ([]string, error)
 }
 
 // RealManager implements Manager using real system calls.
@@ -30,12 +30,12 @@ func (m *RealManager) PollStatus(nsName, socketPath string) ([]Route, error) {
 	return PollStatus(nsName, socketPath)
 }
 
-func (m *RealManager) SyncRoutes(nsName string, routes []Route) error {
-	return SyncRoutes(nsName, routes)
+func (m *RealManager) SyncRoutes(nsName string, routes []Route, infraSubnet string) error {
+	return SyncRoutes(nsName, routes, infraSubnet)
 }
 
-func (m *RealManager) ListRoutes(nsName string) ([]string, error) {
-	return ListRoutes(nsName)
+func (m *RealManager) ListRoutes(nsName string, infraSubnet string) ([]string, error) {
+	return ListRoutes(nsName, infraSubnet)
 }
 
 // Route represents a Tailscale route.
@@ -94,19 +94,21 @@ func parseCIDR(network string) (net.IP, int, error) {
 
 // ListRoutes returns the route destinations currently configured in the namespace.
 // It parses the output of "ip netns exec <ns> ip route show".
-func ListRoutes(nsName string) ([]string, error) {
+func ListRoutes(nsName string, infraSubnet string) ([]string, error) {
 	output, err := exec.Command("ip", "netns", "exec", nsName, "ip", "route", "show").Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list routes in %s: %w", nsName, err)
 	}
-	return parseRouteOutput(string(output)), nil
+	return parseRouteOutput(string(output), infraSubnet), nil
 }
 
 // parseRouteOutput extracts destination CIDRs from ip route show output.
 // Each line starts with the destination (e.g. "10.0.0.0/8 via 192.168.1.1 dev eth0").
 // Lines starting with "default" are skipped since they aren't CIDR routes we manage.
-func parseRouteOutput(output string) []string {
+func parseRouteOutput(output string, infraSubnet string) []string {
 	var routes []string
+	_, infraNet, _ := net.ParseCIDR(infraSubnet)
+
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -123,9 +125,13 @@ func parseRouteOutput(output string) []string {
 		}
 		// Validate it looks like a CIDR
 		if _, _, err := net.ParseCIDR(dest); err == nil {
-			// Skip veth infrastructure routes (10.200.x.0/30) managed by namespace setup
-			if strings.HasPrefix(dest, "10.200.") && strings.HasSuffix(dest, "/30") {
-				continue
+			// Skip veth infrastructure routes managed by namespace setup
+			if infraNet != nil {
+				if destIP, _, err := net.ParseCIDR(dest); err == nil {
+					if infraNet.Contains(destIP) {
+						continue
+					}
+				}
 			}
 			routes = append(routes, dest)
 		}
@@ -136,8 +142,8 @@ func parseRouteOutput(output string) []string {
 // SyncRoutes synchronizes routes to the specified namespace using a diff-based approach.
 // It compares desired routes against actual routes, adding missing and removing stale ones.
 // Individual failures are collected and returned as a combined error.
-func SyncRoutes(namespaceName string, routes []Route) error {
-	actual, err := ListRoutes(namespaceName)
+func SyncRoutes(namespaceName string, routes []Route, infraSubnet string) error {
+	actual, err := ListRoutes(namespaceName, infraSubnet)
 	if err != nil {
 		return fmt.Errorf("failed to list current routes: %w", err)
 	}

--- a/internal/routing/routes_test.go
+++ b/internal/routing/routes_test.go
@@ -164,7 +164,7 @@ func TestParseRouteOutput(t *testing.T) {
 		"192.168.100.0/24 dev eth1 proto kernel scope link src 192.168.100.1",
 	}, "\n")
 
-	got := parseRouteOutput(output)
+	got := parseRouteOutput(output, "10.200.0.0/16")
 	want := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.100.0/24"}
 
 	if len(got) != len(want) {
@@ -181,7 +181,7 @@ func TestListRoutes_ParsesOutput(t *testing.T) {
 	// Test the parseRouteOutput function which is the core of ListRoutes
 	// (ListRoutes itself calls exec which needs root)
 	output := "10.0.0.0/8 via 10.0.0.1 dev eth0\n172.16.0.0/12 dev tun0\ndefault via 10.0.0.1 dev eth0\n"
-	got := parseRouteOutput(output)
+	got := parseRouteOutput(output, "10.200.0.0/16")
 	want := []string{"10.0.0.0/8", "172.16.0.0/12"}
 
 	if !slices.Equal(got, want) {


### PR DESCRIPTION
I am not sure if this handles correctly the 100.100.100.100 address.

I am currently seing:
```
❯ ip r | grep 100.100.100.100
100.100.100.100 via 10.255.1.30 dev vh11304a67c0c3
```

So DNS requests are sent to one of the tailnets.

I use dnsmasq locally to smart route requests to the appropiate server.