### PR TITLE
fix: address PR #16 review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ When host access is enabled for a tailnet, Hydrascale does three things each rec
 
 All of this is automatic and fully managed. Routes and DNS entries are synced every reconciliation cycle and cleaned up on shutdown or when host access is disabled.
 
+### Accepted Subnet Routes
+
+If a tailnet peer advertises subnet routes and your namespace's `tailscaled` is started with `--accept-routes`, Hydrascale automatically propagates those routes to the host. On each reconciliation cycle it reads routing table 52 inside the namespace (where tailscaled installs accepted routes) and adds matching routes on the host pointing via the veth gateway.
+
+To use this, pass `--accept-routes` when logging in:
+
+```bash
+sudo hydrascale tailscale corp-prod -- up --accept-routes
+```
+
+No config change is needed. Subnet routes appear on the host within one reconciliation cycle after login and are removed when the tailnet is torn down.
+
 ### Naming Convention
 
 Each peer gets a prefixed hostname: `<tailnet-id>-<hostname>`. This prevents collisions when multiple tailnets have peers with the same name.
@@ -211,6 +223,23 @@ tailnets:
 
 Per-tailnet `control_url` overrides the global default. Omitting the field (or leaving it empty) uses the standard Tailscale coordination server. This means you can mix Tailscale and Headscale networks on the same host.
 
+### Logging In Without an Auth Key
+
+If you don't use pre-auth keys, you can log in interactively after Hydrascale creates the namespace. Start the daemon (or run `apply`), then use the `tailscale` subcommand to trigger the login flow for each tailnet:
+
+```bash
+# Start Hydrascale (creates namespaces and starts tailscaled)
+sudo hydrascale serve &
+
+# Log in to a Headscale tailnet interactively
+sudo hydrascale tailscale corp-prod -- up --login-server https://headscale.example.com
+
+# For the standard Tailscale coordination server
+sudo hydrascale tailscale personal -- up
+```
+
+Hydrascale prints the auth URL. Open it in a browser, approve the device, and the tailnet comes online. The namespace stays running; Hydrascale manages the lifecycle from that point forward.
+
 ### Important Caveats
 
 - **Auth key format**: Headscale auth keys have a different format than Tailscale's `tskey-auth-*` keys. Hydrascale does not validate the key format -- it passes the key directly to `tailscale up` via `TS_AUTHKEY`. Make sure you use the correct key type for your control server.
@@ -233,6 +262,11 @@ host_access: false
 # Custom control server URL for Headscale (default: empty = use Tailscale)
 # Applied to all tailnets unless overridden per-tailnet. Must be HTTPS.
 # control_url: "https://headscale.example.com"
+
+# Subnet used for internal veth pairs between host and namespaces (default: 10.200.0.0/16)
+# Change this if 10.200.0.0/16 conflicts with an existing route on your network.
+# Must be an IPv4 CIDR of at least /16.
+# infra_subnet: "10.200.0.0/16"
 
 # List of tailnets to manage
 tailnets:
@@ -275,7 +309,9 @@ net.ipv4.ip_forward = 1
 
 ### Veth Pairs
 
-Each namespace is connected to the host via a veth pair. Interface names are derived from a short hash of the tailnet ID (`vh<hash>` on the host side, `vn<hash>` inside the namespace), keeping names within Linux's 15-character interface name limit. Subnets are allocated from `10.200.N.0/30` where N is an index assigned per tailnet.
+Each namespace is connected to the host via a veth pair. Interface names are derived from a short hash of the tailnet ID (`vh<hash>` on the host side, `vn<hash>` inside the namespace), keeping names within Linux's 15-character interface name limit. Each pair gets a dedicated `/30` block allocated sequentially from the infra subnet (default `10.200.0.0/16`).
+
+If `10.200.0.0/16` collides with an existing route on your network, configure a different range with `infra_subnet` (see [Config Reference](#config-reference)). The subnet must be IPv4 and at least a `/16`.
 
 ### NAT / Masquerade
 
@@ -435,6 +471,17 @@ Hydrascale inserts FORWARD ACCEPT rules automatically, but if traffic is still b
 sudo iptables -L FORWARD -v
 ```
 Look for a blanket `DROP` rule positioned before Hydrascale's `ACCEPT` rules and remove or reorder it as needed.
+
+**Infra subnet conflicts with an existing network route**
+If `10.200.0.0/16` overlaps a route already on your host, veth setup will fail or traffic will be misdirected. Confirm the conflict with:
+```bash
+ip route | grep 10.200
+```
+If there is a match, set `infra_subnet` in your config to a free range:
+```yaml
+infra_subnet: "10.201.0.0/16"
+```
+Then restart Hydrascale. Existing namespaces will be torn down and rebuilt with the new addressing.
 
 **"name not a valid ifname"**
 This error occurs with older Hydrascale versions that used full tailnet IDs as interface names, which exceed Linux's 15-character limit. Update to the latest release, which uses hash-based veth names (`vh<hash>`/`vn<hash>`) that always fit within the limit.

--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -80,15 +81,14 @@ func loadConfig() (*config.Config, error) {
 }
 
 func newReconciler() *reconciler.Reconciler {
-	cfg, _ := loadConfig()
-	infraSubnet := "10.200.0.0/16"
-	if cfg != nil && cfg.InfraSubnet != "" {
-		infraSubnet = cfg.InfraSubnet
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
 	}
 	ns := namespaces.NewRealManager()
 	dm := daemon.NewRealManager()
 	rt := routing.NewRealManager()
-	return reconciler.New(configPath(), ns, dm, rt, 10*time.Second, nil, infraSubnet)
+	return reconciler.New(configPath(), ns, dm, rt, 10*time.Second, nil, cfg.InfraSubnet)
 }
 
 // --- Declarative commands ---

--- a/internal/hostaccess/routes_test.go
+++ b/internal/hostaccess/routes_test.go
@@ -154,3 +154,66 @@ func TestRouteSync_NoOp(t *testing.T) {
 		t.Errorf("NoOp: expected no routes to remove, got %v", toRemove)
 	}
 }
+
+func TestMergeRoutes(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{
+			name: "no overlap",
+			a:    []string{"10.0.0.0/8", "172.16.0.0/12"},
+			b:    []string{"192.168.1.0/24"},
+			want: []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.1.0/24"},
+		},
+		{
+			name: "full overlap deduped",
+			a:    []string{"10.0.0.0/8"},
+			b:    []string{"10.0.0.0/8"},
+			want: []string{"10.0.0.0/8"},
+		},
+		{
+			name: "partial overlap",
+			a:    []string{"10.0.0.0/8", "172.16.0.0/12"},
+			b:    []string{"172.16.0.0/12", "192.168.1.0/24"},
+			want: []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.1.0/24"},
+		},
+		{
+			name: "empty a",
+			a:    nil,
+			b:    []string{"10.0.0.0/8"},
+			want: []string{"10.0.0.0/8"},
+		},
+		{
+			name: "empty b",
+			a:    []string{"10.0.0.0/8"},
+			b:    nil,
+			want: []string{"10.0.0.0/8"},
+		},
+		{
+			name: "both empty",
+			a:    nil,
+			b:    nil,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeRoutes(tt.a, tt.b)
+			sort.Strings(got)
+			wantSorted := append([]string(nil), tt.want...)
+			sort.Strings(wantSorted)
+			if len(got) != len(wantSorted) {
+				t.Fatalf("mergeRoutes(%v, %v) = %v, want %v", tt.a, tt.b, got, wantSorted)
+			}
+			for i := range wantSorted {
+				if got[i] != wantSorted[i] {
+					t.Errorf("mergeRoutes[%d] = %q, want %q", i, got[i], wantSorted[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/namespaces/ns.go
+++ b/internal/namespaces/ns.go
@@ -148,8 +148,8 @@ func GetTailnetFromNamespace(namespaceName string) string {
 	return ""
 }
 
-// VethIndex returns a deterministic index (1-254) for a namespace name,
-// used to pick the /30 subnet: 10.200.{index}.0/30.
+// VethIndex returns a deterministic index (1-254) for a namespace name.
+// The index selects a /30 block within the configured infra subnet.
 func VethIndex(nsName string) int {
 	h := sha256.Sum256([]byte(nsName))
 	v := int(binary.BigEndian.Uint32(h[:4]))
@@ -186,6 +186,10 @@ func VethIPs(infraSubnet string, index int) (hostIP, nsIP, hostGW, nsGW string, 
 	binary.BigEndian.PutUint32(ip1, uHostIP)
 	ip2 := make(net.IP, 4)
 	binary.BigEndian.PutUint32(ip2, uNsIP)
+
+	if !ipnet.Contains(ip1) || !ipnet.Contains(ip2) {
+		return "", "", "", "", fmt.Errorf("veth index %d out of range for subnet %s", index, infraSubnet)
+	}
 
 	return ip1.String() + "/30", ip2.String() + "/30", ip1.String(), ip2.String(), nil
 }

--- a/internal/namespaces/ns_test.go
+++ b/internal/namespaces/ns_test.go
@@ -1,6 +1,9 @@
 package namespaces
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGetNamespaceName(t *testing.T) {
 	tests := []struct {
@@ -36,6 +39,98 @@ func TestGetTailnetFromNamespace(t *testing.T) {
 		if got := GetTailnetFromNamespace(tt.namespaceName); got != tt.want {
 			t.Errorf("GetTailnetFromNamespace(%q) = %q, want %q", tt.namespaceName, got, tt.want)
 		}
+	}
+}
+
+func TestVethIPs(t *testing.T) {
+	tests := []struct {
+		name        string
+		subnet      string
+		index       int
+		wantHostIP  string
+		wantNsIP    string
+		wantHostGW  string
+		wantNsGW    string
+		wantErrFrag string
+	}{
+		{
+			name:       "default subnet index 1",
+			subnet:     "10.200.0.0/16",
+			index:      1,
+			wantHostIP: "10.200.0.1/30",
+			wantNsIP:   "10.200.0.2/30",
+			wantHostGW: "10.200.0.1",
+			wantNsGW:   "10.200.0.2",
+		},
+		{
+			name:       "default subnet index 2",
+			subnet:     "10.200.0.0/16",
+			index:      2,
+			wantHostIP: "10.200.0.5/30",
+			wantNsIP:   "10.200.0.6/30",
+			wantHostGW: "10.200.0.5",
+			wantNsGW:   "10.200.0.6",
+		},
+		{
+			name:       "custom subnet index 1",
+			subnet:     "192.168.50.0/16",
+			index:      1,
+			wantHostIP: "192.168.0.1/30",
+			wantNsIP:   "192.168.0.2/30",
+			wantHostGW: "192.168.0.1",
+			wantNsGW:   "192.168.0.2",
+		},
+		{
+			name:       "max index 254",
+			subnet:     "10.200.0.0/16",
+			index:      254,
+			wantHostIP: "10.200.3.245/30",
+			wantNsIP:   "10.200.3.246/30",
+			wantHostGW: "10.200.3.245",
+			wantNsGW:   "10.200.3.246",
+		},
+		{
+			name:        "invalid subnet",
+			subnet:      "not-a-cidr",
+			index:       1,
+			wantErrFrag: "invalid CIDR",
+		},
+		{
+			name:        "index out of range for small subnet",
+			subnet:      "10.50.0.0/24",
+			index:       200,
+			wantErrFrag: "out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostIP, nsIP, hostGW, nsGW, err := VethIPs(tt.subnet, tt.index)
+			if tt.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrFrag)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrFrag) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hostIP != tt.wantHostIP {
+				t.Errorf("hostIP = %q, want %q", hostIP, tt.wantHostIP)
+			}
+			if nsIP != tt.wantNsIP {
+				t.Errorf("nsIP = %q, want %q", nsIP, tt.wantNsIP)
+			}
+			if hostGW != tt.wantHostGW {
+				t.Errorf("hostGW = %q, want %q", hostGW, tt.wantHostGW)
+			}
+			if nsGW != tt.wantNsGW {
+				t.Errorf("nsGW = %q, want %q", nsGW, tt.wantNsGW)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Follow-up to #16 (merged). Addresses the three issues flagged during review.

## Changes

**`newReconciler` config error swallow** — Previously the function silently fell back to `10.200.0.0/16` if the config failed to load, meaning a broken config would cause `hydrascale diff`/`apply` to operate against the wrong veth range with no warning. Now it calls `log.Fatalf` on error, consistent with how `serveCmd` treats a bad config.

**`VethIPs` bounds assertion** — Adds a check that the computed host and namespace IPs actually land inside the provided subnet. The `/16` minimum in config validation already makes overflow impossible in practice, but the assertion keeps `VethIPs` honest if that bound is ever relaxed.

**`VethIndex` comment** — Removed the hardcoded `10.200.{index}.0/30` example from the comment since the subnet is now configurable.

## Tests added

- `TestVethIPs` — covers default subnet, custom subnet, max index (254), invalid CIDR, and out-of-range index for a small subnet
- `TestMergeRoutes` — covers no-overlap, full-overlap dedup, partial overlap, empty inputs

All existing tests continue to pass.