### PR TITLE
fix: unwedge MagicDNS on daemon restart and write real namespace upstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,11 @@ When host access is enabled for a tailnet, Hydrascale does four things each reco
 
 All of this is automatic and fully managed. Routes and DNS entries are synced every reconciliation cycle and cleaned up on shutdown or when host access is disabled.
 
-> **Note on `--accept-dns`:** Hydrascale runs `tailscale up --accept-dns=true` inside each namespace so tailscaled enables its MagicDNS proxy at `100.100.100.100:53`. Without this, the DNAT path would have no listener inside the namespace and FQDN queries would return SERVFAIL. If you upgrade from a version before this fix and your daemons have `CorpDNS=false` persisted in their state, run `sudo hydrascale tailscale <id> -- set --accept-dns=true` once per tailnet to flip it.
+> **Note on tailscaled DNS lifecycle.** Two subtleties matter for per-tailnet MagicDNS, and Hydrascale handles both automatically:
+>
+> 1. **Namespace upstreams.** Each namespace gets `/etc/netns/<ns>/resolv.conf` populated with real host upstream resolvers (sourced from `/run/systemd/resolve/resolv.conf` or `/etc/resolv.conf`, loopbacks filtered, falling back to `1.1.1.1`). Writing `100.100.100.100` there would leave tailscaled's resolver chain empty, because tailscaled filters its own address as a self-loop — and an empty chain returns SERVFAIL for every query, including names it could answer locally from the peer table.
+>
+> 2. **Daemon restart refresh.** When the reconciler restarts an unhealthy tailscaled, the new process loads state from disk but does not re-read `resolv.conf`, which can leave its MagicDNS proxy wedged. Hydrascale waits for `BackendState=Running` and then toggles `--accept-dns=false` → `--accept-dns=true` to force a resolver-chain rebuild. This recovers DNS automatically on every restart — no manual `tailscale set` required.
 
 ### Accepted Subnet Routes
 
@@ -489,6 +493,17 @@ Then restart Hydrascale. Existing namespaces will be torn down and rebuilt with 
 
 **"name not a valid ifname"**
 This error occurs with older Hydrascale versions that used full tailnet IDs as interface names, which exceed Linux's 15-character limit. Update to the latest release, which uses hash-based veth names (`vh<hash>`/`vn<hash>`) that always fit within the limit.
+
+**MagicDNS returns SERVFAIL for tailnet FQDNs**
+First confirm the log shows `refresh_dns` running after `start_daemon` on the affected tailnet:
+```bash
+journalctl -u hydrascale | grep -E 'start_daemon|refresh_dns'
+```
+If `refresh_dns` is missing or timed out, tailscaled probably never reached `BackendState=Running` (bad auth, no network, control server unreachable). Check `sudo hydrascale tailscale <id> -- status` inside the namespace. If `refresh_dns` ran but queries still SERVFAIL, inspect the namespace resolv.conf — it must contain real upstreams, not `100.100.100.100`:
+```bash
+cat /etc/netns/ns-<id>/resolv.conf
+```
+As a last resort, force a full refresh by restarting the service: `sudo systemctl restart hydrascale`. The reconciler will re-run the DNS refresh flow on the next cycle.
 
 ## License
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -102,6 +102,8 @@ func (m *mockDaemon) GetSocketPath(tailnetID string) string {
 
 func (m *mockDaemon) AuthorizeDaemon(tailnetID, nsName, authKey, controlURL string) error { return nil }
 
+func (m *mockDaemon) RefreshDNSConfig(tailnetID, nsName string) error { return nil }
+
 func (m *mockDaemon) GetStatus(ctx context.Context, nsName, tailnetID string) (*daemon.TailscaleStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -39,6 +39,7 @@ type Manager interface {
 	CheckHealth(nsName, tailnetID string) (bool, error)
 	GetSocketPath(tailnetID string) string
 	AuthorizeDaemon(tailnetID, nsName, authKey, controlURL string) error
+	RefreshDNSConfig(tailnetID, nsName string) error
 	GetStatus(ctx context.Context, nsName, tailnetID string) (*TailscaleStatus, error)
 }
 
@@ -68,6 +69,10 @@ func (m *RealManager) GetSocketPath(tailnetID string) string {
 
 func (m *RealManager) AuthorizeDaemon(tailnetID, nsName, authKey, controlURL string) error {
 	return AuthorizeDaemon(tailnetID, nsName, authKey, controlURL)
+}
+
+func (m *RealManager) RefreshDNSConfig(tailnetID, nsName string) error {
+	return RefreshDNSConfig(tailnetID, nsName)
 }
 
 func (m *RealManager) GetStatus(ctx context.Context, nsName, tailnetID string) (*TailscaleStatus, error) {
@@ -299,6 +304,89 @@ func AuthorizeDaemon(tailnetID, nsName, authKey, controlURL string) error {
 	}
 
 	log.Printf("Authorized tailnet %s in namespace %s", tailnetID, nsName)
+	return nil
+}
+
+// RefreshDNSConfig forces tailscaled to re-initialize its DNS configuration
+// by toggling --accept-dns off and back on. This is required after a daemon
+// restart from an existing state file: tailscaled caches its resolver chain
+// in memory and does not re-read /etc/resolv.conf on startup. If the previous
+// chain was wedged (e.g. only contained 100.100.100.100, which tailscaled
+// filters as a self-loop), the MagicDNS proxy returns SERVFAIL for every
+// query — including names it could answer locally from the peer table.
+//
+// The off→on transition causes tailscaled to rebuild the resolver chain from
+// the current namespace resolv.conf, picking up real upstreams and unwedging
+// the proxy. The toggle only produces a real teardown/rebuild once the
+// backend is in the Running state; if we fire it earlier, the pref changes
+// just become the initial prefs applied when the netmap eventually arrives,
+// and no DNS rebuild happens. So poll for BackendState=Running first.
+func RefreshDNSConfig(tailnetID, nsName string) error {
+	socketPath := SocketPath(tailnetID)
+
+	// Phase 1: wait for socket to appear (StartDaemon is non-blocking).
+	sockDeadline := time.After(30 * time.Second)
+	sockTick := time.NewTicker(500 * time.Millisecond)
+	defer sockTick.Stop()
+
+	sockReady := false
+	for !sockReady {
+		select {
+		case <-sockDeadline:
+			return fmt.Errorf("timeout waiting for tailscaled socket for %s", tailnetID)
+		case <-sockTick.C:
+			if _, err := os.Stat(socketPath); err == nil {
+				sockReady = true
+			}
+		}
+	}
+
+	// Phase 2: wait for BackendState=Running. Login + netmap typically takes
+	// 2–10 seconds after socket creation; 60s gives slow networks headroom.
+	runDeadline := time.After(60 * time.Second)
+	runTick := time.NewTicker(500 * time.Millisecond)
+	defer runTick.Stop()
+
+	running := false
+	for !running {
+		select {
+		case <-runDeadline:
+			return fmt.Errorf("timeout waiting for tailscaled Running state for %s", tailnetID)
+		case <-runTick.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			cmd := exec.CommandContext(ctx, "ip", "netns", "exec", nsName,
+				"tailscale", "--socket="+socketPath, "status", "--json")
+			output, err := cmd.Output()
+			cancel()
+			if err != nil {
+				continue
+			}
+			var s struct {
+				BackendState string `json:"BackendState"`
+			}
+			if json.Unmarshal(output, &s) != nil {
+				continue
+			}
+			if s.BackendState == "Running" {
+				running = true
+			}
+		}
+	}
+
+	// Phase 3: real flip-flop against a stable, connected daemon.
+	for _, val := range []string{"false", "true"} {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		cmd := exec.CommandContext(ctx, "ip", "netns", "exec", nsName,
+			"tailscale", "--socket="+socketPath, "set", "--accept-dns="+val)
+		output, err := cmd.CombinedOutput()
+		cancel()
+		if err != nil {
+			return fmt.Errorf("tailscale set --accept-dns=%s failed for %s: %v (%s)",
+				val, tailnetID, err, strings.TrimSpace(string(output)))
+		}
+	}
+
+	log.Printf("Refreshed DNS config for tailnet %s (accept-dns flip-flop)", tailnetID)
 	return nil
 }
 

--- a/internal/namespaces/ns.go
+++ b/internal/namespaces/ns.go
@@ -344,18 +344,73 @@ func SetupHostAccess(nsName string, index int, infraSubnet string) error {
 	}
 
 	// /etc/netns/NAME/resolv.conf
+	//
+	// Tailscaled's DNS proxy requires at least one reachable, non-loopback
+	// upstream resolver to answer queries — even for names it could satisfy
+	// locally from its peer table. If its resolver chain is empty (or only
+	// contains 100.100.100.100 itself, which it filters out as a self-loop),
+	// it returns SERVFAIL for every query. So write real host upstreams here,
+	// not 100.100.100.100. Queries that arrive at tailscaled via the veth DNAT
+	// path still work: tailscaled answers MagicDNS locally and forwards the
+	// rest to these upstreams.
 	netnsDir := filepath.Join("/etc/netns", nsName)
 	if err := os.MkdirAll(netnsDir, 0755); err != nil {
 		log.Printf("host-access: failed to create %s: %v", netnsDir, err)
 	} else {
 		resolvPath := filepath.Join(netnsDir, "resolv.conf")
-		if err := os.WriteFile(resolvPath, []byte("nameserver 100.100.100.100\n"), 0644); err != nil {
+		upstreams := resolveHostUpstreams()
+		var buf strings.Builder
+		for _, ns := range upstreams {
+			buf.WriteString("nameserver ")
+			buf.WriteString(ns)
+			buf.WriteString("\n")
+		}
+		if err := os.WriteFile(resolvPath, []byte(buf.String()), 0644); err != nil {
 			log.Printf("host-access: failed to write %s: %v", resolvPath, err)
 		}
 	}
 
 	log.Printf("Set up host access rules for namespace %s", nsName)
 	return nil
+}
+
+// resolveHostUpstreams returns DNS upstreams reachable from inside a namespace.
+// It prefers /run/systemd/resolve/resolv.conf (real upstreams, bypassing the
+// systemd-resolved stub) and falls back to /etc/resolv.conf. Loopback addresses
+// are filtered out because 127.0.0.x on the host is not reachable from inside
+// the namespace. If no usable upstream is found, 1.1.1.1 is returned as a
+// last-resort default.
+func resolveHostUpstreams() []string {
+	candidates := []string{
+		"/run/systemd/resolve/resolv.conf",
+		"/etc/resolv.conf",
+	}
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var found []string
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "nameserver") {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			ip := net.ParseIP(fields[1])
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			found = append(found, ip.String())
+		}
+		if len(found) > 0 {
+			return found
+		}
+	}
+	return []string{"1.1.1.1"}
 }
 
 // TeardownHostAccess removes namespace-side host access iptables rules and resolv.conf.

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -34,6 +34,7 @@ const (
 	ActionSyncRoutes     ActionType = "sync_routes"
 	ActionSyncHostAccess ActionType = "sync_host_access"
 	ActionAuthDaemon     ActionType = "auth_daemon"
+	ActionRefreshDNS     ActionType = "refresh_dns"
 )
 
 // MaxFailures is the number of consecutive failures before a tailnet enters error state.
@@ -207,7 +208,14 @@ func (r *Reconciler) Diff(desired map[string]config.Tailnet, actual map[string]*
 				actions = append(actions, Action{Type: ActionAuthDaemon, TailnetID: id, NsName: ns, AuthKey: authKey, ControlURL: controlURL})
 			}
 		} else if !state.DaemonHealthy {
+			// Restart path: tailscaled loads state from disk but doesn't re-read
+			// resolv.conf, so its MagicDNS resolver chain can come up wedged.
+			// Follow the start with a DNS refresh (accept-dns flip-flop) to
+			// force tailscaled to rebuild the chain from the current namespace
+			// resolv.conf. Without this, dig @100.100.100.100 returns SERVFAIL
+			// for every query until someone manually runs `tailscale set`.
 			actions = append(actions, Action{Type: ActionStartDaemon, TailnetID: id, NsName: ns})
+			actions = append(actions, Action{Type: ActionRefreshDNS, TailnetID: id, NsName: ns})
 		} else {
 			// Daemon healthy, sync routes
 			actions = append(actions, Action{Type: ActionSyncRoutes, TailnetID: id, NsName: ns})
@@ -289,6 +297,8 @@ func (r *Reconciler) executeAction(action Action) error {
 		return r.dm.Stop(action.NsName, action.TailnetID)
 	case ActionAuthDaemon:
 		return r.dm.AuthorizeDaemon(action.TailnetID, action.NsName, action.AuthKey, action.ControlURL)
+	case ActionRefreshDNS:
+		return r.dm.RefreshDNSConfig(action.TailnetID, action.NsName)
 	case ActionSyncRoutes:
 		socketPath := r.dm.GetSocketPath(action.TailnetID)
 		routes, err := r.rt.PollStatus(action.NsName, socketPath)

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -127,6 +127,10 @@ func (m *mockDaemon) AuthorizeDaemon(tailnetID, nsName, authKey, controlURL stri
 	return nil
 }
 
+func (m *mockDaemon) RefreshDNSConfig(tailnetID, nsName string) error {
+	return nil
+}
+
 func (m *mockDaemon) GetStatus(ctx context.Context, nsName, tailnetID string) (*daemon.TailscaleStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -310,6 +314,24 @@ func TestDiff_UnhealthyDaemon(t *testing.T) {
 	}
 	if counts[ActionCreateNS] != 0 {
 		t.Errorf("create_ns = %d, want 0 (ns exists)", counts[ActionCreateNS])
+	}
+	// Restart path must also refresh DNS so tailscaled rebuilds its resolver
+	// chain from resolv.conf — loading state from disk leaves MagicDNS wedged.
+	if counts[ActionRefreshDNS] != 1 {
+		t.Errorf("refresh_dns = %d, want 1 (restart path must refresh DNS)", counts[ActionRefreshDNS])
+	}
+	// And the refresh must come after the start.
+	var startIdx, refreshIdx = -1, -1
+	for i, a := range actions {
+		if a.Type == ActionStartDaemon {
+			startIdx = i
+		}
+		if a.Type == ActionRefreshDNS {
+			refreshIdx = i
+		}
+	}
+	if startIdx == -1 || refreshIdx == -1 || refreshIdx < startIdx {
+		t.Errorf("refresh_dns must be scheduled after start_daemon; got start=%d refresh=%d", startIdx, refreshIdx)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #19 / Issue #17. Two bugs surfaced during end-to-end testing on the Jetson after #19 merged — both tailnets were still returning SERVFAIL for every MagicDNS query until someone manually ran `tailscale set`. Fixes both, end-to-end verified.

### Bug 1: namespace resolv.conf pointed tailscaled at itself

`SetupHostAccess` wrote `nameserver 100.100.100.100` into `/etc/netns/<ns>/resolv.conf`. tailscaled filters its own magic address as a self-loop, so its resolver chain came up **empty** — and an empty chain returns SERVFAIL for *every* query, including names it could answer locally from the peer table.

**Fix:** `resolveHostUpstreams()` now reads `/run/systemd/resolve/resolv.conf` (real upstreams, bypassing the systemd-resolved stub) with `/etc/resolv.conf` as fallback, filters loopbacks, and falls back to `1.1.1.1` if nothing usable is found. Those real upstreams are written into the namespace resolv.conf. Queries that arrive at tailscaled via the veth DNAT path still work: tailscaled answers MagicDNS locally and forwards the rest to these upstreams.

### Bug 2: daemon restart left MagicDNS wedged

On the reconciler restart path (`nsExists && !DaemonHealthy`), tailscaled reloads state from disk but never re-reads resolv.conf — so if the resolver chain was previously wedged, it comes up wedged again. Only the fresh-auth path ran `tailscale up`, so a restart left DNS broken until a human intervened.

**Fix:** new `ActionRefreshDNS` + `daemon.RefreshDNSConfig`. Emitted after `ActionStartDaemon` on the restart path. It:

1. Waits for the tailscaled socket to appear.
2. Polls `tailscale status --json` until `BackendState == "Running"` (up to 60s).
3. Toggles `--accept-dns=false` → `--accept-dns=true` against the now-connected daemon, forcing a real resolver-chain teardown and rebuild from the current namespace resolv.conf.

The Running-state poll is load-bearing: flipping the pref before login completes just updates stored prefs without producing a real DNS rebuild, leaving the proxy wedged. First pass of Fix #2 shipped without this poll and did not recover the daemon — caught on the Jetson and fixed before landing.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `TestDiff_UnhealthyDaemon` extended to assert `ActionRefreshDNS` is scheduled after `ActionStartDaemon` on the restart path
- [x] Installed on Jetson, restarted `hydrascale.service`
- [x] Confirmed log sequence: `start_daemon` → wait → `refresh_dns` (havoc took 3s to reach Running, personal 1s)
- [x] `dig @127.0.0.53 -p 5354 bigboy.taildf854a.ts.net +short` → `100.73.198.12` ✅
- [x] `dig @127.0.0.53 -p 5354 mars.tailfe323c.ts.net +short` → `100.102.63.67` ✅
- [x] External resolution (`google.com`) via the forwarder still works
- [x] Zero manual `tailscale set` intervention required

Closes the remaining MagicDNS-on-restart issues from #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)