### PR TITLE
chore(release): auto-detect prereleases from tag suffix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,3 +34,6 @@ checksum:
 changelog:
   sort: asc
   use: github-native
+
+release:
+  prerelease: auto


### PR DESCRIPTION
## Summary

- Add `release.prerelease: auto` to `.goreleaser.yaml`
- Goreleaser will then mark tags like `v*-rc`, `v*-beta`, `v*-alpha` (and numeric variants like `-rc1`) as GitHub pre-releases automatically — no API patching after the fact.

## Why

When v0.7.2-rc1 was published, goreleaser created it as a normal release and the rc1 took over the `Latest` slot from v0.7.1. Had to flip it via `PATCH /releases/{id} -F prerelease=true -F make_latest=false` after the workflow ran. With this change, future `-rc/-beta/-alpha` tags will publish correctly out of the box.

## Test plan

- [ ] Manual verification: cut a throwaway pre-release tag (e.g. `v0.0.0-test1`) on this branch's HEAD after merge, confirm it publishes as a Pre-release with `Latest` flag staying on v0.7.1, then delete the tag and release.
- [x] No code paths affected; pure release-pipeline config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)