### PR TITLE
fix: sync hydrascale install systemd unit with contrib (closes #25)

### DIFF
--- a/cmd/hydrascale/hydrascale.service
+++ b/cmd/hydrascale/hydrascale.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Hydrascale - Multi-Tailnet Manager
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/hydrascale serve --config /etc/hydrascale/config.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5s
+WorkingDirectory=/var/lib/hydrascale
+
+# Note: systemd sandboxing (ProtectSystem, NoNewPrivileges, ProtectHome)
+# is intentionally omitted. Hydrascale requires full access to iptables,
+# network namespaces (/run/netns), and mount propagation to the host.
+# Sandboxing breaks namespace visibility and iptables-legacy on some kernels.
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hydrascale
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/hydrascale/install_test.go
+++ b/cmd/hydrascale/install_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSystemdUnitMatchesContrib guards against the regression in issue #25:
+// `hydrascale install` used to embed a duplicate systemd unit string that
+// drifted from contrib/hydrascale.service, so fixes to the contrib file
+// (removing incompatible sandboxing) silently failed to reach installed
+// systems. Keep them byte-identical.
+func TestSystemdUnitMatchesContrib(t *testing.T) {
+	contribPath := filepath.Join("..", "..", "contrib", "hydrascale.service")
+	contrib, err := os.ReadFile(contribPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", contribPath, err)
+	}
+	if string(contrib) != systemdUnit {
+		t.Fatalf("embedded systemd unit drifted from %s.\n"+
+			"Update cmd/hydrascale/hydrascale.service to match contrib/hydrascale.service "+
+			"(or vice versa) so `hydrascale install` writes the same content users get "+
+			"when they copy the contrib file manually.", contribPath)
+	}
+}

--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"log"
 	"os"
@@ -25,6 +26,13 @@ import (
 )
 
 var cfgFile string
+
+// systemdUnit is the canonical content of /etc/systemd/system/hydrascale.service
+// written by `hydrascale install`. Must stay byte-identical to
+// contrib/hydrascale.service — enforced by TestSystemdUnitMatchesContrib.
+//
+//go:embed hydrascale.service
+var systemdUnit string
 
 func main() {
 	var rootCmd = &cobra.Command{
@@ -773,32 +781,7 @@ Run with --dry-run to see what would be done without making changes.`,
 				{
 					desc: "Install systemd unit",
 					fn: func() error {
-						unit := `[Unit]
-Description=Hydrascale - Multi-Tailnet Manager
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/hydrascale serve --config /etc/hydrascale/config.yaml
-ExecReload=/bin/kill -HUP $MAINPID
-Restart=on-failure
-RestartSec=5s
-WorkingDirectory=/var/lib/hydrascale
-AmbientCapabilities=CAP_NET_ADMIN CAP_SYS_ADMIN
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_SYS_ADMIN
-NoNewPrivileges=yes
-ProtectSystem=strict
-ReadWritePaths=/var/lib/hydrascale /run/netns /etc/hydrascale /var/log/hydrascale /run/tailscale
-ProtectHome=yes
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=hydrascale
-
-[Install]
-WantedBy=multi-user.target
-`
-						return os.WriteFile("/etc/systemd/system/hydrascale.service", []byte(unit), 0644)
+						return os.WriteFile("/etc/systemd/system/hydrascale.service", []byte(systemdUnit), 0644)
 					},
 				},
 				{


### PR DESCRIPTION
## Summary

Fixes #25. `hydrascale install` was writing a systemd unit with sandboxing directives that were already removed from `contrib/hydrascale.service` in commits bf1c16e and 899d4a8 — so users who copied the contrib file manually got a working unit, but users who ran `hydrascale install` got the broken one (iptables-legacy fails, namespace visibility breaks on Tegra/Jetson).

Root cause: the install command embedded a duplicate of the unit as a Go string literal. The two copies drifted.

## Fix

- `cmd/hydrascale/main.go` — replace the inlined string with `//go:embed hydrascale.service`. Install writes the embedded bytes.
- `cmd/hydrascale/hydrascale.service` — canonical embed source (byte-identical to `contrib/hydrascale.service`; `go:embed` can't traverse `..` so the file lives in the package dir).
- `cmd/hydrascale/install_test.go` — `TestSystemdUnitMatchesContrib` asserts the two files stay byte-identical. Prevents this exact regression.

Confirmed the test fails on drift (added a stray newline → fail; reverted → pass).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 10 packages pass, including the new regression test
- [x] Drift test verified meaningful (fails when files diverge, passes when in sync)
- [ ] Reviewer to spot-check that `cmd/hydrascale/hydrascale.service` and `contrib/hydrascale.service` are identical (they are; `diff` returns no output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)