### PR TITLE
feat: hydrascale init setup wizard + uninstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test-config.yaml
 config.yaml
 .hydrascale.lock
 .worktrees/
+/vendor/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Requirements](#requirements)
 - [Install](#install)
 - [Quick Start](#quick-start)
+- [Uninstall](#uninstall)
 - [Host Access](#host-access) -- transparent access to all tailnet peers from the host
 - [Headscale / Custom Control Server](#headscale--custom-control-server)
 - [Config Reference](#config-reference)
@@ -41,6 +42,7 @@ The reconciler runs as a control loop: on each tick it reads the config, inspect
 - **iproute2** (`ip` command for namespace management)
 - **iptables** (NAT masquerading and forwarding rules)
 - **Kernel network namespace support** (`CONFIG_NET_NS`, standard on all modern kernels)
+- **Kernel policy routing** (`CONFIG_IP_MULTIPLE_TABLES`, `CONFIG_IPV6_MULTIPLE_TABLES`) — only needed for [Host Access](#host-access) route propagation (accepting subnet routes onto the host). Standard on most distro kernels; some SBC/Jetson kernels omit it, in which case host route propagation is silently a no-op.
 - **IP forwarding enabled**: `sudo sysctl -w net.ipv4.ip_forward=1`
 
 ## Install
@@ -71,6 +73,16 @@ sudo install hydrascale /usr/local/bin/
 
 ## Quick Start
 
+The fastest path is the interactive wizard. It runs preflight checks, generates
+the config, sets up authentication (auth key or browser login), brings your first
+tailnet up, and verifies it authenticated:
+
+```bash
+sudo hydrascale init
+```
+
+To configure manually instead:
+
 1. Create a config file at `/var/lib/hydrascale/config.yaml`:
 
 ```yaml
@@ -97,6 +109,21 @@ sudo hydrascale apply
 ```bash
 sudo hydrascale serve
 ```
+
+## Uninstall
+
+To completely remove Hydrascale — stop all tailnets, delete their namespaces,
+veths, iptables rules, host routes, and DNS entries, then remove the systemd
+service and `/var/lib/hydrascale`:
+
+```bash
+sudo hydrascale uninstall
+```
+
+By default each tailnet node is deregistered (logged out) so it doesn't linger
+in your tailnet admin; pass `--keep-nodes` to skip that. A plain `uninstall`
+leaves the binary and `/etc/hydrascale` in place so it stays re-runnable — add
+`--purge` to remove those too. Use `--yes` to skip the confirmation prompt.
 
 ## Host Access
 
@@ -337,6 +364,7 @@ hydrascale apply                      One-shot reconciliation (apply config to s
 hydrascale diff                       Show what would change without applying
 hydrascale env <tailnet-id>           Print shell environment for a tailnet namespace
 hydrascale exec <tailnet-id> -- <cmd> Run a command inside a tailnet's network namespace
+hydrascale init                       Interactive first-run setup wizard
 hydrascale install                    Install Hydrascale as a systemd service
 hydrascale list                       List all configured tailnets
 hydrascale ping <tailnet-id> <target> Ping a Tailscale peer from within a tailnet's namespace
@@ -348,6 +376,7 @@ hydrascale switch <id>                Switch the default namespace for direct ta
 hydrascale tailscale <tailnet-id> -- <args>
                                       Run an arbitrary tailscale command inside a tailnet's namespace
 hydrascale tui                        Open the monitoring TUI (requires running daemon via serve)
+hydrascale uninstall                  Completely tear down Hydrascale (--purge also removes the binary)
 hydrascale wrap <service> <tailnet-id>
                                       Generate systemd drop-in for namespace isolation
 ```
@@ -471,6 +500,25 @@ IP forwarding is not enabled. Check and enable it:
 ```bash
 sudo sysctl net.ipv4.ip_forward          # should print 1
 sudo sysctl -w net.ipv4.ip_forward=1     # enable if not set
+```
+
+**Host can't resolve public names / native tailscaled fights hydrascale's DNS**
+If the host also runs its own `tailscaled` with `accept-dns` on, it rewrites
+`/etc/resolv.conf` to point only at MagicDNS (`100.100.100.100`). If that tailnet
+has no public upstream configured, the host loses public DNS and hydrascale's
+resolver inherits the dead upstream. Disable the host tailscaled's DNS management
+and hand `/etc/resolv.conf` back to systemd-resolved:
+```bash
+sudo tailscale set --accept-dns=false
+sudo ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+```
+`hydrascale init` detects this during preflight and offers to disable it.
+
+**"failed to listen on /var/lib/hydrascale/api.sock: no such file or directory"**
+The state directory doesn't exist yet. `hydrascale init` and `hydrascale install`
+create it; to do it manually:
+```bash
+sudo mkdir -p /var/lib/hydrascale/state
 ```
 
 **Docker blocking namespace traffic**

--- a/cmd/hydrascale/init.go
+++ b/cmd/hydrascale/init.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"hydrascale/internal/config"
+
+	"github.com/spf13/cobra"
+)
+
+func initCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Interactive first-run setup wizard",
+		Long: `init walks you through preflight checks, generates a config, sets up
+authentication (auth key or browser login), brings your first tailnet up, and
+prints how to use it. Run as root.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			force, _ := cmd.Flags().GetBool("force")
+			return runInit(force)
+		},
+	}
+	cmd.Flags().Bool("force", false, "Overwrite an existing config (backs up the old one to .bak)")
+	return cmd
+}
+
+func runInit(force bool) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("init must run as root (it creates namespaces and system directories); try: sudo hydrascale init")
+	}
+	p := newPrompter(os.Stdin, os.Stdout)
+
+	fmt.Println("Hydrascale setup")
+	fmt.Println("================")
+
+	// Existing-config guard.
+	path := configPath()
+	var existing *config.Config
+	if _, err := os.Stat(path); err == nil && !force {
+		fmt.Printf("\nA config already exists at %s\n", path)
+		switch strings.ToLower(p.line("[a]dd a tailnet, [r]ecreate (backs up the old one), or [q]uit?", "a")) {
+		case "q":
+			return nil
+		case "r":
+			if err := backupFile(path); err != nil {
+				return fmt.Errorf("back up existing config: %w", err)
+			}
+			fmt.Printf("Backed up to %s.bak\n", path)
+		default:
+			cfg, err := config.LoadConfig(path)
+			if err != nil {
+				return fmt.Errorf("load existing config: %w", err)
+			}
+			existing = cfg
+		}
+	}
+
+	runPreflight(p)
+
+	// Prompt one or more tailnets. Keys are collected separately and never
+	// written to the config; they are exported as HYDRASCALE_AUTHKEY_<ID>.
+	var answers []tailnetAnswers
+	keys := map[string]string{}
+	for {
+		a, key := promptTailnet(p)
+		answers = append(answers, a)
+		if a.UseKey && key != "" {
+			keys[a.ID] = key
+		}
+		if !p.yesNo("Add another tailnet?", false) {
+			break
+		}
+	}
+
+	// Build (or merge into existing) config. Global host_access stays false;
+	// tailnets that want it get an explicit per-tailnet override.
+	var cfg *config.Config
+	if existing != nil {
+		cfg = existing
+		cfg.Tailnets = append(cfg.Tailnets, buildConfig(answers, existing.HostAccess).Tailnets...)
+	} else {
+		cfg = buildConfig(answers, false)
+	}
+
+	for _, d := range []string{"/var/lib/hydrascale/state", "/var/log/hydrascale"} {
+		if err := os.MkdirAll(d, 0750); err != nil {
+			return fmt.Errorf("create %s: %w", d, err)
+		}
+	}
+	if err := config.SaveConfig(path, cfg); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	fmt.Printf("\nWrote config to %s\n", path)
+
+	// Export keys for the in-process first run and show how to persist them.
+	for id, key := range keys {
+		os.Setenv(config.AuthKeyEnvVar(id), key)
+		fmt.Printf("  Persist for restarts: export %s=<your-key>\n", config.AuthKeyEnvVar(id))
+	}
+
+	printCheatSheet()
+	fmt.Println("\nNext: run 'sudo hydrascale apply' to bring your tailnets up.")
+	return nil
+}
+
+// promptTailnet collects answers for one tailnet, returning the answers and the
+// raw auth key (empty for browser auth).
+func promptTailnet(p *prompter) (tailnetAnswers, string) {
+	var a tailnetAnswers
+	for {
+		a.ID = p.line("Tailnet id (e.g. personal, work)", "")
+		if config.IsValidID(a.ID) {
+			break
+		}
+		fmt.Println("  invalid id — letters/digits/dots/hyphens/underscores, start alphanumeric, max 63 chars")
+	}
+	a.HostAccess = p.yesNo("Enable host access (reach this tailnet's peers directly from the host)?", false)
+	a.ExitNode = p.line("Exit node hostname (optional, blank for none)", "")
+
+	if strings.HasPrefix(strings.ToLower(p.line("Authenticate with an auth [k]ey or [b]rowser login?", "k")), "k") {
+		a.UseKey = true
+		key, err := p.secret("Paste auth key (tskey-auth-...)")
+		if err != nil {
+			fmt.Printf("  could not read key (%v); falling back to browser login\n", err)
+			a.UseKey = false
+			return a, ""
+		}
+		return a, key
+	}
+	return a, ""
+}
+
+// runPreflight reports environment readiness and offers to fix common problems.
+func runPreflight(p *prompter) {
+	fmt.Println("\nPreflight:")
+	for _, bin := range []string{"tailscale", "tailscaled", "iptables", "ip"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			fmt.Printf("  ✗ %s not found in PATH\n", bin)
+		} else {
+			fmt.Printf("  ✓ %s found\n", bin)
+		}
+	}
+
+	if v, _ := os.ReadFile("/proc/sys/net/ipv4/ip_forward"); strings.TrimSpace(string(v)) != "1" {
+		fmt.Println("  ✗ net.ipv4.ip_forward is disabled")
+		if p.yesNo("    Enable IP forwarding now (and persist)?", true) {
+			_ = exec.Command("sysctl", "-w", "net.ipv4.ip_forward=1").Run()
+			_ = os.WriteFile("/etc/sysctl.d/99-hydrascale.conf", []byte("net.ipv4.ip_forward=1\n"), 0644)
+			fmt.Println("    enabled")
+		}
+	} else {
+		fmt.Println("  ✓ IP forwarding enabled")
+	}
+
+	if hasPolicyRouting() {
+		fmt.Println("  ✓ kernel policy routing (multiple tables) available")
+	} else {
+		fmt.Println("  ! CONFIG_IP_MULTIPLE_TABLES not detected — host route propagation for accepted subnet routes will not work on this kernel")
+	}
+
+	if nativeTailscaleAcceptDNS() {
+		fmt.Println("  ! the host's own tailscaled has accept-dns enabled — it hijacks /etc/resolv.conf and fights hydrascale's DNS")
+		if p.yesNo("    Disable it now (tailscale set --accept-dns=false)?", true) {
+			_ = exec.Command("tailscale", "set", "--accept-dns=false").Run()
+			fmt.Println("    disabled")
+		}
+	}
+}
+
+// hasPolicyRouting reports whether the kernel was built with multiple routing
+// tables (needed for host-route propagation). Returns true when undetectable so
+// we don't raise a false alarm.
+func hasPolicyRouting() bool {
+	if data, ok := readMaybeGzip("/proc/config.gz"); ok {
+		return strings.Contains(data, "CONFIG_IP_MULTIPLE_TABLES=y")
+	}
+	rel, err := exec.Command("uname", "-r").Output()
+	if err != nil {
+		return true
+	}
+	data, err := os.ReadFile("/boot/config-" + strings.TrimSpace(string(rel)))
+	if err != nil {
+		return true
+	}
+	return strings.Contains(string(data), "CONFIG_IP_MULTIPLE_TABLES=y")
+}
+
+// readMaybeGzip reads a gzipped file, returning its decompressed contents.
+func readMaybeGzip(path string) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", false
+	}
+	defer gz.Close()
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// nativeTailscaleAcceptDNS reports whether a host-level tailscaled has accept-dns on.
+func nativeTailscaleAcceptDNS() bool {
+	out, err := exec.Command("tailscale", "debug", "prefs").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "\"CorpDNS\": true")
+}
+
+func backupFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path+".bak", data, 0640)
+}
+
+// printCheatSheet shows how to run commands inside tailnet namespaces.
+func printCheatSheet() {
+	fmt.Println("\nHow to use your tailnets:")
+	fmt.Println("  Run a command:            sudo hydrascale exec <id> -- <cmd>")
+	fmt.Println("  Quick tools:              hydrascale ssh|ping|tailscale <id> ...")
+	fmt.Println("  Default THIS shell:       eval \"$(hydrascale env <id>)\"")
+	fmt.Println("  Set a persistent default: hydrascale switch <id>")
+	fmt.Println("  Run a service in-ns:      hydrascale wrap <service> <id>")
+}

--- a/cmd/hydrascale/init.go
+++ b/cmd/hydrascale/init.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"hydrascale/internal/config"
+	"hydrascale/internal/daemon"
+	"hydrascale/internal/namespaces"
 
 	"github.com/spf13/cobra"
 )
@@ -103,9 +106,107 @@ func runInit(force bool) error {
 		fmt.Printf("  Persist for restarts: export %s=<your-key>\n", config.AuthKeyEnvVar(id))
 	}
 
+	return firstRunAndVerify(p, cfg, answers)
+}
+
+// firstRunAndVerify reconciles the new config to bring tailnets up, verifies
+// each one authenticated (retrying auth-key logins that raced), prints the
+// namespace cheat-sheet, and offers to install the boot service.
+func firstRunAndVerify(p *prompter, cfg *config.Config, answers []tailnetAnswers) error {
+	fmt.Println("\nBringing tailnets up...")
+	r := newReconciler()
+	r.ResetAllErrors()
+	if err := r.Reconcile(); err != nil {
+		fmt.Printf("  reconcile reported: %v\n", err)
+	}
+
+	fmt.Println("\nAuthentication:")
+	for _, a := range answers {
+		verifyAuth(a)
+	}
+
 	printCheatSheet()
-	fmt.Println("\nNext: run 'sudo hydrascale apply' to bring your tailnets up.")
+
+	if p.yesNo("\nInstall as a systemd service so tailnets start on boot?", false) {
+		self, err := os.Executable()
+		if err != nil {
+			fmt.Printf("  cannot locate own binary: %v\n", err)
+			return nil
+		}
+		c := exec.Command(self, "install")
+		c.Stdout, c.Stderr = os.Stdout, os.Stderr
+		if err := c.Run(); err != nil {
+			fmt.Printf("  install failed: %v\n", err)
+		}
+	}
 	return nil
+}
+
+// verifyAuth checks that a tailnet's namespace is authenticated. For auth-key
+// tailnets it retries `up --authkey` once if the initial login raced; for
+// browser tailnets it prints the login URL and polls until logged in.
+func verifyAuth(a tailnetAnswers) {
+	status, _ := nsTailscaleStatus(a.ID)
+	if isLoggedIn(status) {
+		fmt.Printf("  ✓ %s: authenticated\n", a.ID)
+		return
+	}
+
+	if a.UseKey {
+		if key := os.Getenv(config.AuthKeyEnvVar(a.ID)); key != "" {
+			ns := namespaces.GetNamespaceName(a.ID)
+			sock := daemon.SocketPath(a.ID)
+			_ = exec.Command("ip", "netns", "exec", ns, "tailscale", "--socket="+sock,
+				"up", "--accept-dns=true", "--authkey="+key).Run()
+			if status, _ = nsTailscaleStatus(a.ID); isLoggedIn(status) {
+				fmt.Printf("  ✓ %s: authenticated (after retry)\n", a.ID)
+				return
+			}
+		}
+		fmt.Printf("  ✗ %s: not authenticated — verify the auth key and re-run\n", a.ID)
+		return
+	}
+
+	url := loginURL(status)
+	if url == "" {
+		fmt.Printf("  ✗ %s: no login URL available yet — check 'hydrascale tailscale %s -- status'\n", a.ID, a.ID)
+		return
+	}
+	fmt.Printf("  → %s: open this URL to log in:\n      %s\n    waiting up to 2m...\n", a.ID, url)
+	for i := 0; i < 40; i++ {
+		time.Sleep(3 * time.Second)
+		if status, _ = nsTailscaleStatus(a.ID); isLoggedIn(status) {
+			fmt.Printf("  ✓ %s: authenticated\n", a.ID)
+			return
+		}
+	}
+	fmt.Printf("  ✗ %s: timed out waiting for browser login\n", a.ID)
+}
+
+// nsTailscaleStatus returns the output of `tailscale status` inside a tailnet's namespace.
+func nsTailscaleStatus(id string) (string, error) {
+	ns := namespaces.GetNamespaceName(id)
+	sock := daemon.SocketPath(id)
+	out, err := exec.Command("ip", "netns", "exec", ns, "tailscale", "--socket="+sock, "status").CombinedOutput()
+	return string(out), err
+}
+
+// isLoggedIn reports whether a `tailscale status` output indicates an authenticated node.
+func isLoggedIn(status string) bool {
+	if strings.Contains(status, "Logged out") || strings.Contains(status, "Log in at") || strings.Contains(status, "NeedsLogin") {
+		return false
+	}
+	return strings.TrimSpace(status) != ""
+}
+
+// loginURL extracts the interactive login URL from a `tailscale status` output.
+func loginURL(status string) string {
+	for _, f := range strings.Fields(status) {
+		if strings.HasPrefix(f, "https://login.tailscale.com/") {
+			return f
+		}
+	}
+	return ""
 }
 
 // promptTailnet collects answers for one tailnet, returning the answers and the

--- a/cmd/hydrascale/init_test.go
+++ b/cmd/hydrascale/init_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestIsLoggedIn(t *testing.T) {
+	loggedOut := "Logged out.\nLog in at: https://login.tailscale.com/a/abc123\n"
+	loggedIn := "100.72.247.43  mars-1  johhnybones28@  linux  -\n"
+	cases := map[string]bool{
+		loggedOut:      false,
+		loggedIn:       true,
+		"":             false,
+		"NeedsLogin\n": false,
+		"   \n":        false,
+	}
+	for in, want := range cases {
+		if got := isLoggedIn(in); got != want {
+			t.Errorf("isLoggedIn(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestLoginURL(t *testing.T) {
+	status := "Logged out.\n\nTo authenticate, visit:\n\n\thttps://login.tailscale.com/a/deadbeef\n\n"
+	if got := loginURL(status); got != "https://login.tailscale.com/a/deadbeef" {
+		t.Errorf("loginURL = %q", got)
+	}
+	if got := loginURL("100.72.247.43 mars-1 johhnybones28@ linux -"); got != "" {
+		t.Errorf("loginURL(logged-in) = %q, want empty", got)
+	}
+}

--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -50,6 +50,7 @@ reconciles toward it. GitOps for tailnets.`,
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is "+config.DefaultConfigPath+")")
 
+	rootCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(addCmd())
 	rootCmd.AddCommand(removeCmd())
 	rootCmd.AddCommand(listCmd())

--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -67,6 +67,7 @@ reconciles toward it. GitOps for tailnets.`,
 	rootCmd.AddCommand(wrapCmd())
 	rootCmd.AddCommand(envCmd())
 	rootCmd.AddCommand(installCmd())
+	rootCmd.AddCommand(uninstallCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/hydrascale/prompt.go
+++ b/cmd/hydrascale/prompt.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// prompter reads interactive answers from an input stream and writes questions
+// to an output stream. secretFn reads a value without echoing it (masked); it is
+// overridable in tests.
+type prompter struct {
+	in       *bufio.Reader
+	out      io.Writer
+	secretFn func() (string, error)
+}
+
+// newPrompter returns a prompter reading from in and writing prompts to out.
+// By default secret input is read from the terminal without echo.
+func newPrompter(in io.Reader, out io.Writer) *prompter {
+	return &prompter{
+		in:  bufio.NewReader(in),
+		out: out,
+		secretFn: func() (string, error) {
+			b, err := term.ReadPassword(os.Stdin.Fd())
+			return string(b), err
+		},
+	}
+}
+
+// line asks a question and returns the trimmed response, or def when the
+// response is empty.
+func (p *prompter) line(question, def string) string {
+	if def != "" {
+		fmt.Fprintf(p.out, "%s [%s]: ", question, def)
+	} else {
+		fmt.Fprintf(p.out, "%s: ", question)
+	}
+	text, _ := p.in.ReadString('\n')
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return def
+	}
+	return text
+}
+
+// yesNo asks a yes/no question and returns the parsed answer, or def when the
+// response is empty or unrecognised.
+func (p *prompter) yesNo(question string, def bool) bool {
+	hint := "y/N"
+	if def {
+		hint = "Y/n"
+	}
+	fmt.Fprintf(p.out, "%s [%s]: ", question, hint)
+	text, _ := p.in.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(text)) {
+	case "y", "yes":
+		return true
+	case "n", "no":
+		return false
+	default:
+		return def
+	}
+}
+
+// secret asks for a value read without echo (e.g. an auth key) and returns it
+// trimmed.
+func (p *prompter) secret(question string) (string, error) {
+	fmt.Fprintf(p.out, "%s: ", question)
+	v, err := p.secretFn()
+	fmt.Fprintln(p.out)
+	return strings.TrimSpace(v), err
+}

--- a/cmd/hydrascale/prompt.go
+++ b/cmd/hydrascale/prompt.go
@@ -67,11 +67,16 @@ func (p *prompter) yesNo(question string, def bool) bool {
 	}
 }
 
-// secret asks for a value read without echo (e.g. an auth key) and returns it
-// trimmed.
+// secret asks for a value and returns it trimmed. On a real terminal the input
+// is read without echo (masked); otherwise (piped input) it is read as a normal
+// line from the same buffered reader, so it stays consistent with line/yesNo.
 func (p *prompter) secret(question string) (string, error) {
 	fmt.Fprintf(p.out, "%s: ", question)
-	v, err := p.secretFn()
-	fmt.Fprintln(p.out)
-	return strings.TrimSpace(v), err
+	if term.IsTerminal(os.Stdin.Fd()) {
+		v, err := p.secretFn()
+		fmt.Fprintln(p.out)
+		return strings.TrimSpace(v), err
+	}
+	line, err := p.in.ReadString('\n')
+	return strings.TrimSpace(line), err
 }

--- a/cmd/hydrascale/prompt_test.go
+++ b/cmd/hydrascale/prompt_test.go
@@ -39,9 +39,10 @@ func TestPromptYesNo(t *testing.T) {
 	}
 }
 
-func TestPromptSecretTrims(t *testing.T) {
-	p := newPrompter(strings.NewReader(""), io.Discard)
-	p.secretFn = func() (string, error) { return "tskey-abc  ", nil }
+func TestPromptSecretFromReader(t *testing.T) {
+	// Under `go test`, stdin is not a terminal, so secret reads a trimmed line
+	// from the same buffered reader as line/yesNo.
+	p := newPrompter(strings.NewReader("tskey-abc  \n"), io.Discard)
 	got, err := p.secret("auth key")
 	if err != nil || got != "tskey-abc" {
 		t.Fatalf("secret = %q err=%v, want tskey-abc", got, err)

--- a/cmd/hydrascale/prompt_test.go
+++ b/cmd/hydrascale/prompt_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestPromptLineDefault(t *testing.T) {
+	p := newPrompter(strings.NewReader("\n"), io.Discard)
+	if got := p.line("id", "personal"); got != "personal" {
+		t.Fatalf("line empty = %q, want personal (default)", got)
+	}
+	p2 := newPrompter(strings.NewReader("  work \n"), io.Discard)
+	if got := p2.line("id", "personal"); got != "work" {
+		t.Fatalf("line = %q, want work (trimmed)", got)
+	}
+}
+
+func TestPromptYesNo(t *testing.T) {
+	cases := []struct {
+		in   string
+		def  bool
+		want bool
+	}{
+		{"y\n", false, true},
+		{"YES\n", false, true},
+		{"n\n", true, false},
+		{"no\n", true, false},
+		{"\n", true, true},
+		{"\n", false, false},
+		{"huh\n", true, true},
+	}
+	for _, c := range cases {
+		p := newPrompter(strings.NewReader(c.in), io.Discard)
+		if got := p.yesNo("ok?", c.def); got != c.want {
+			t.Errorf("yesNo(%q, def=%v) = %v, want %v", c.in, c.def, got, c.want)
+		}
+	}
+}
+
+func TestPromptSecretTrims(t *testing.T) {
+	p := newPrompter(strings.NewReader(""), io.Discard)
+	p.secretFn = func() (string, error) { return "tskey-abc  ", nil }
+	got, err := p.secret("auth key")
+	if err != nil || got != "tskey-abc" {
+		t.Fatalf("secret = %q err=%v, want tskey-abc", got, err)
+	}
+}

--- a/cmd/hydrascale/uninstall.go
+++ b/cmd/hydrascale/uninstall.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"hydrascale/internal/config"
+	"hydrascale/internal/daemon"
+	"hydrascale/internal/namespaces"
+
+	"github.com/spf13/cobra"
+)
+
+func uninstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Completely tear down Hydrascale (namespaces, routes, service, config)",
+		Long: `uninstall stops all tailnets, deletes their namespaces and the routes,
+iptables rules, and DNS entries they created, removes the systemd service and
+/var/lib/hydrascale. With --purge it also removes the binary and /etc/hydrascale.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			yes, _ := cmd.Flags().GetBool("yes")
+			purge, _ := cmd.Flags().GetBool("purge")
+			keepNodes, _ := cmd.Flags().GetBool("keep-nodes")
+			return runUninstall(yes, purge, keepNodes)
+		},
+	}
+	cmd.Flags().Bool("yes", false, "Do not prompt for confirmation")
+	cmd.Flags().Bool("purge", false, "Also remove the binary and /etc/hydrascale")
+	cmd.Flags().Bool("keep-nodes", false, "Do not deregister (log out) tailnet nodes")
+	return cmd
+}
+
+func runUninstall(yes, purge, keepNodes bool) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("uninstall must run as root; try: sudo hydrascale uninstall")
+	}
+	p := newPrompter(os.Stdin, os.Stdout)
+
+	fmt.Println("This will remove Hydrascale from this system:")
+	fmt.Println("  - stop + disable the systemd service")
+	fmt.Println("  - tear down all tailnet namespaces, veths, iptables rules, host routes, DNS entries")
+	fmt.Println("  - remove /var/lib/hydrascale and /var/log/hydrascale")
+	if purge {
+		fmt.Println("  - remove the hydrascale binary and /etc/hydrascale (--purge)")
+	}
+	if !yes && !p.yesNo("Proceed?", false) {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	// 1. Stop the running service first so it doesn't fight the teardown.
+	if isServiceActive("hydrascale") {
+		_ = exec.Command("systemctl", "stop", "hydrascale").Run()
+	}
+	_ = exec.Command("systemctl", "disable", "hydrascale").Run()
+
+	// 2. Deregister nodes (best-effort) before their namespaces go away.
+	path := configPath()
+	cfg, err := config.LoadConfig(path)
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+	if !keepNodes {
+		for _, tn := range cfg.Tailnets {
+			logoutNamespace(tn.ID)
+		}
+	}
+
+	// 3. Reconcile toward an empty desired state to tear down every namespace,
+	//    veth, iptables rule, host route, and DNS entry — the same path `remove` uses.
+	if len(cfg.Tailnets) > 0 {
+		empty := *cfg
+		empty.Tailnets = nil
+		if saveErr := config.SaveConfig(path, &empty); saveErr == nil {
+			if rErr := newReconciler().Reconcile(); rErr != nil {
+				fmt.Printf("  teardown reconcile reported: %v\n", rErr)
+			}
+		}
+	}
+
+	// 4. Remove state, service unit, and (with --purge) binary + config.
+	var removed []string
+	for _, d := range []string{"/var/lib/hydrascale", "/var/log/hydrascale"} {
+		if err := os.RemoveAll(d); err == nil {
+			removed = append(removed, d)
+		}
+	}
+	if err := os.Remove("/etc/systemd/system/hydrascale.service"); err == nil {
+		removed = append(removed, "/etc/systemd/system/hydrascale.service")
+		_ = exec.Command("systemctl", "daemon-reload").Run()
+	}
+	if purge {
+		for _, f := range []string{"/etc/hydrascale", "/usr/local/bin/hydrascale"} {
+			if err := os.RemoveAll(f); err == nil {
+				removed = append(removed, f)
+			}
+		}
+	}
+
+	fmt.Println("\nRemoved:")
+	for _, r := range removed {
+		fmt.Printf("  - %s\n", r)
+	}
+	fmt.Println("Hydrascale uninstalled. (If any tailnet was mid-teardown, a reboot fully clears namespaces.)")
+	return nil
+}
+
+// isServiceActive reports whether a systemd unit is active.
+func isServiceActive(name string) bool {
+	out, _ := exec.Command("systemctl", "is-active", name).Output()
+	return strings.TrimSpace(string(out)) == "active"
+}
+
+// logoutNamespace best-effort deregisters a tailnet node from its namespace.
+func logoutNamespace(id string) {
+	ns := namespaces.GetNamespaceName(id)
+	sock := daemon.SocketPath(id)
+	_ = exec.Command("ip", "netns", "exec", ns, "tailscale", "--socket="+sock, "logout").Run()
+}

--- a/cmd/hydrascale/wizard_config.go
+++ b/cmd/hydrascale/wizard_config.go
@@ -1,0 +1,32 @@
+package main
+
+import "hydrascale/internal/config"
+
+// tailnetAnswers holds the wizard responses for a single tailnet.
+type tailnetAnswers struct {
+	ID         string
+	HostAccess bool
+	ExitNode   string
+	UseKey     bool // key vs. browser auth; affects the auth flow, not the config
+}
+
+// buildConfig turns wizard answers into a Config. Auth keys are never written
+// to the config (they go to the HYDRASCALE_AUTHKEY_<ID> env var); a per-tailnet
+// host_access override is only emitted when it differs from the global default.
+func buildConfig(ans []tailnetAnswers, globalHostAccess bool) *config.Config {
+	cfg := &config.Config{
+		Version:    2,
+		HostAccess: globalHostAccess,
+		Resolver:   config.ResolverConfig{Mode: "unified", BindAddress: "127.0.0.53:5354"},
+		Reconciler: config.ReconcilerConfig{RawInterval: "10s"},
+	}
+	for _, a := range ans {
+		tn := config.Tailnet{ID: a.ID, ExitNode: a.ExitNode}
+		if a.HostAccess != globalHostAccess {
+			v := a.HostAccess
+			tn.HostAccess = &v
+		}
+		cfg.Tailnets = append(cfg.Tailnets, tn)
+	}
+	return cfg
+}

--- a/cmd/hydrascale/wizard_config_test.go
+++ b/cmd/hydrascale/wizard_config_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestBuildConfig(t *testing.T) {
+	cfg := buildConfig([]tailnetAnswers{
+		{ID: "personal", HostAccess: true, UseKey: true},
+		{ID: "work", HostAccess: false, ExitNode: "exit.tail1234.ts.net"},
+	}, false)
+
+	if cfg.Version != 2 {
+		t.Errorf("Version = %d, want 2", cfg.Version)
+	}
+	if cfg.Resolver.Mode != "unified" || cfg.Resolver.BindAddress != "127.0.0.53:5354" {
+		t.Errorf("Resolver = %+v", cfg.Resolver)
+	}
+	if cfg.Reconciler.RawInterval != "10s" {
+		t.Errorf("interval = %q, want 10s", cfg.Reconciler.RawInterval)
+	}
+	if len(cfg.Tailnets) != 2 {
+		t.Fatalf("tailnets = %d, want 2", len(cfg.Tailnets))
+	}
+
+	// personal: host_access differs from global(false) -> explicit override true.
+	if cfg.Tailnets[0].HostAccess == nil || !*cfg.Tailnets[0].HostAccess {
+		t.Errorf("personal host_access override = %v, want true", cfg.Tailnets[0].HostAccess)
+	}
+	// keys never land in the config.
+	if cfg.Tailnets[0].AuthKey != "" {
+		t.Errorf("personal AuthKey = %q, want empty (env var)", cfg.Tailnets[0].AuthKey)
+	}
+	// work: matches global(false) -> no override; exit node carried through.
+	if cfg.Tailnets[1].HostAccess != nil {
+		t.Errorf("work host_access override = %v, want nil", cfg.Tailnets[1].HostAccess)
+	}
+	if cfg.Tailnets[1].ExitNode != "exit.tail1234.ts.net" {
+		t.Errorf("work ExitNode = %q", cfg.Tailnets[1].ExitNode)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/miekg/dns v1.1.72
 	github.com/spf13/cobra v1.8.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -17,7 +18,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,10 +213,17 @@ func ValidateBindAddress(addr string) error {
 	return nil
 }
 
+// AuthKeyEnvVar returns the environment variable name that overrides the auth
+// key for a tailnet: HYDRASCALE_AUTHKEY_<ID>, where <ID> is uppercased with
+// dashes replaced by underscores (e.g. "corp-prod" -> HYDRASCALE_AUTHKEY_CORP_PROD).
+func AuthKeyEnvVar(id string) string {
+	return "HYDRASCALE_AUTHKEY_" + strings.ToUpper(strings.ReplaceAll(id, "-", "_"))
+}
+
 // ResolveAuthKey returns the auth key for a tailnet, checking env var first, then config.
 // Env var format: HYDRASCALE_AUTHKEY_<ID> where ID is uppercased with dashes replaced by underscores.
 func ResolveAuthKey(tailnetID string, configKey string) string {
-	envKey := "HYDRASCALE_AUTHKEY_" + strings.ToUpper(strings.ReplaceAll(tailnetID, "-", "_"))
+	envKey := AuthKeyEnvVar(tailnetID)
 	if v := os.Getenv(envKey); v != "" {
 		return v
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -252,6 +252,19 @@ func TestResolveAuthKey_Neither(t *testing.T) {
 	}
 }
 
+func TestAuthKeyEnvVar(t *testing.T) {
+	cases := map[string]string{
+		"personal":  "HYDRASCALE_AUTHKEY_PERSONAL",
+		"corp-prod": "HYDRASCALE_AUTHKEY_CORP_PROD",
+		"home-lab-1": "HYDRASCALE_AUTHKEY_HOME_LAB_1",
+	}
+	for in, want := range cases {
+		if got := AuthKeyEnvVar(in); got != want {
+			t.Errorf("AuthKeyEnvVar(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestLoadConfigHostAccess(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
## Summary

Adds an interactive **`hydrascale init`** first-run wizard and a mirror **`hydrascale uninstall`** teardown command to lower the setup barrier, plus targeted docs.

The namespace-usage commands (`exec`/`env`/`switch`/`wrap`) already existed; the wizard's value is removing the *setup* friction: choosing auth (key vs. browser), generating valid YAML, preflight checks, and creating the state dir that `serve` needs.

### `hydrascale init`
- **Preflight:** tailscale/iptables/ip in PATH, IP forwarding (offers to enable+persist), kernel policy routing (`CONFIG_IP_MULTIPLE_TABLES`) for host-route features, and a **native-tailscaled `accept-dns` conflict check** (it hijacks `/etc/resolv.conf` and fights hydrascale's DNS — offers to disable).
- **Guided config** per tailnet (id/host-access/exit-node), auth key **or** browser login. Keys are exported as `HYDRASCALE_AUTHKEY_<ID>`, never written to `config.yaml`.
- **Live first-run + auth verify:** reconciles the tailnet up and confirms it authenticated. Auth-key logins that race (the `tailscale up` timeout → interactive fallback) are **retried once with `up --authkey`** and re-checked. Browser logins print the URL and poll.
- Prints a namespace cheat-sheet, then offers to install the boot service.
- Existing-config guard (`[a]dd/[r]ecreate/[q]uit`); `--force` to recreate.

### `hydrascale uninstall`
- Stops+disables the service, best-effort deregisters nodes (`--keep-nodes` to skip), tears down all namespaces/veths/iptables/routes/DNS by reconciling toward an empty config (same path as `remove`), removes state dirs. `--purge` also removes the binary and `/etc/hydrascale`. Confirmation-gated unless `--yes`.

### Docs
Quick Start leads with `init`; new Uninstall section; `CONFIG_IP_MULTIPLE_TABLES` requirement; troubleshooting for the native-tailscaled DNS conflict and the `api.sock` state-dir.

## Implementation notes
- No new dependencies: masked key input reuses the already-vendored `charmbracelet/x/term` (promoted to direct). `go 1.24` directive and the rest of the module graph untouched.
- Pure logic (prompts, config generation, env-var naming, status parsing) is unit-tested; system-touching orchestration is integration-tested.

## Testing
- `go build`/`go vet`/unit tests green (x86_64 Linux).
- **Live end-to-end on x86 hardware (kernel 6.17):**
  - `init` (auth-key path): preflight → config → reconcile → **auth raced (`signal: killed`) and the retry recovered → `✓ authenticated (after retry)`** → namespace up, host networking intact.
  - `uninstall --yes`: torn down cleanly, host left fully clean (no namespaces, no `vh` routes, no managed iptables/hosts blocks, dirs removed), LAN + DNS + internet intact, no hang.
