### PR TITLE
fix: shield host /etc/resolv.conf with per-namespace /etc overlay (#28)

### DIFF
--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -51,6 +51,7 @@ reconciles toward it. GitOps for tailnets.`,
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is "+config.DefaultConfigPath+")")
 
 	rootCmd.AddCommand(initCmd())
+	rootCmd.AddCommand(nsDaemonCmd())
 	rootCmd.AddCommand(addCmd())
 	rootCmd.AddCommand(removeCmd())
 	rootCmd.AddCommand(listCmd())

--- a/cmd/hydrascale/nsdaemon.go
+++ b/cmd/hydrascale/nsdaemon.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+// nsDaemonCmd is an internal helper, not part of the user-facing CLI. It is
+// invoked as `ip netns exec <ns> hydrascale __nsdaemon --etc-upper U --etc-work W -- <cmd...>`.
+// Running inside the private mount namespace that `ip netns exec` set up, it
+// mounts a per-namespace overlay on /etc so that anything the child writes to
+// /etc (notably tailscaled's resolv.conf, which it replaces via rename) lands
+// in the namespace-local upper dir instead of the host's shared /etc. Then it
+// execs the child. See issue #28.
+func nsDaemonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "__nsdaemon",
+		Hidden: true,
+		Args:   cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			upper, _ := cmd.Flags().GetString("etc-upper")
+			work, _ := cmd.Flags().GetString("etc-work")
+			dash := cmd.ArgsLenAtDash()
+			if dash < 0 || dash >= len(args) {
+				return fmt.Errorf("__nsdaemon requires '-- <command...>'")
+			}
+			return runNsDaemon(upper, work, args[dash:])
+		},
+	}
+	cmd.Flags().String("etc-upper", "", "overlay upperdir for /etc")
+	cmd.Flags().String("etc-work", "", "overlay workdir for /etc")
+	return cmd
+}
+
+// runNsDaemon mounts the per-namespace /etc overlay (best-effort) then execs the child.
+func runNsDaemon(upper, work string, cmdArgs []string) error {
+	if upper != "" && work != "" {
+		// Fresh dirs each launch: overlay requires an empty workdir, and a stale
+		// upper resolv.conf would shadow the current one until tailscaled rewrites it.
+		_ = os.RemoveAll(upper)
+		_ = os.RemoveAll(work)
+		if err := os.MkdirAll(upper, 0755); err != nil {
+			return fmt.Errorf("create overlay upperdir: %w", err)
+		}
+		if err := os.MkdirAll(work, 0755); err != nil {
+			return fmt.Errorf("create overlay workdir: %w", err)
+		}
+		opts := fmt.Sprintf("lowerdir=/etc,upperdir=%s,workdir=%s", upper, work)
+		if err := syscall.Mount("overlay", "/etc", "overlay", 0, opts); err != nil {
+			// Don't fail the daemon over the shield; log and continue so the
+			// tailnet still comes up (falls back to pre-#28 behaviour).
+			fmt.Fprintf(os.Stderr, "hydrascale __nsdaemon: overlay /etc failed: %v (continuing without host-DNS shield)\n", err)
+		}
+	}
+	bin, err := exec.LookPath(cmdArgs[0])
+	if err != nil {
+		return fmt.Errorf("locate %q: %w", cmdArgs[0], err)
+	}
+	return syscall.Exec(bin, cmdArgs, os.Environ())
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -117,8 +117,23 @@ func StartDaemon(tailnetID string, namespaceName string) error {
 	os.Remove(socketPath)
 	stateFile := filepath.Join(stateDir, "tailscaled.state")
 
+	// Launch tailscaled through the hydrascale __nsdaemon helper, which mounts a
+	// per-namespace overlay on /etc first. tailscaled replaces /etc/resolv.conf
+	// via rename; a single-file bind-mount can't contain that, so writes would
+	// otherwise land in the host's shared /etc and clobber host DNS. The overlay
+	// keeps every /etc write namespace-local. See issue #28.
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot locate hydrascale binary: %w", err)
+	}
+	etcUpper := filepath.Join(stateDir, "etc-upper")
+	etcWork := filepath.Join(stateDir, "etc-work")
 	args := []string{
 		"netns", "exec", namespaceName,
+		self, "__nsdaemon",
+		"--etc-upper", etcUpper,
+		"--etc-work", etcWork,
+		"--",
 		"tailscaled",
 		"--state=" + stateFile,
 		"--socket=" + socketPath,


### PR DESCRIPTION
Closes #28.

## Problem
With `host_access` enabled, bringing hydrascale up intermittently rewrote the **host's** `/etc/resolv.conf` to `nameserver 100.100.100.100` (MagicDNS), breaking host public DNS.

## Root cause (confirmed live via bpftrace + mount-namespace forensics, x86 / kernel 6.17)
The #22 shield bind-mounts a single **file** (`/etc/netns/<ns>/resolv.conf` over `/etc/resolv.conf`). tailscale's Linux "direct" DNS manager writes resolv.conf as **write-temp + `rename()`**. A rename replaces the *directory entry* in `/etc`; since only the file (not `/etc`) is bind-mounted and `/etc` is shared with the host, the rename lands in the host's `/etc` — clobbering host DNS **and** detaching the shield in one move. That's why it appeared intermittent: the host is only clobbered after the daemon's next DNS write since (re)start.

## Fix
Launch the namespaced `tailscaled` through a new internal `__nsdaemon` helper. Running inside the mount namespace `ip netns exec` created, it mounts a per-namespace **overlay on `/etc`** (`lowerdir=/etc`, per-ns `upperdir`/`workdir`) before exec'ing tailscaled. Every `/etc` write — including the resolv.conf rename — stays namespace-local; the host `/etc` is never touched, and the daemon still reads host `/etc` (certs, `nsswitch.conf`, …) via the lower layer.

- `cmd/hydrascale/nsdaemon.go` — the helper (`syscall.Mount` overlay → `syscall.Exec` child).
- `internal/daemon/daemon.go` — `StartDaemon` now launches via the helper with per-ns `state/<id>/etc-{upper,work}`.
- Best-effort: if the overlay mount fails, it logs and still starts the daemon (falls back to pre-#28 behaviour) rather than failing the tailnet.

## Validation (x86 testbed, kernel 6.17, both systemd-resolved + openresolv-shim present)
- Overlay-on-`/etc` primitive confirmed (rename-write captured in the per-ns upper; host `/etc` untouched; lower-layer reads still work).
- Repro test (toggle `accept-dns` → check host `/etc/resolv.conf`): **FAIL before → PASS after**.
- In-namespace MagicDNS still works (`ns` resolv.conf = `100.100.100.100`).
- The prior immutable-`resolv.conf` workaround is no longer needed; host resolv.conf stays as the systemd-resolved stub across accept-dns toggles on both tailnets.
- `go build`/`go vet`/tests green.
