### PR TITLE
fix: auth-key via --auth-key flag (#31) + state-dir cleanup on remove (#32)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -265,11 +265,19 @@ func CheckHealth(namespaceName string, tailnetID string) (bool, error) {
 
 // buildTailscaleUpArgs constructs the argument list for `tailscale up`.
 // When controlURL is non-empty, --login-server is appended (for Headscale).
-func buildTailscaleUpArgs(socketPath, controlURL string) []string {
+func buildTailscaleUpArgs(socketPath, controlURL, authKeyFile string) []string {
 	// --accept-dns=true is required so tailscaled enables its MagicDNS proxy
 	// at 100.100.100.100:53 inside the namespace. The hostaccess forwarder
 	// routes per-tailnet queries to that endpoint via DNAT on the veth.
 	args := []string{"tailscale", "--socket=" + socketPath, "up", "--accept-dns=true"}
+	// `tailscale up` reads the auth key from the --auth-key flag, NOT from the
+	// TS_AUTHKEY environment variable (that is consumed by tailscaled, not the
+	// CLI) — passing it via the env makes `up` fall back to interactive login
+	// and time out. The file: form keeps the key out of argv (ps) and the
+	// environment. See issue #31.
+	if authKeyFile != "" {
+		args = append(args, "--auth-key=file:"+authKeyFile)
+	}
 	if controlURL != "" {
 		args = append(args, "--login-server="+controlURL)
 	}
@@ -302,14 +310,33 @@ func AuthorizeDaemon(tailnetID, nsName, authKey, controlURL string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tsArgs := buildTailscaleUpArgs(socketPath, controlURL)
+	// tailscale up takes the key from --auth-key, not TS_AUTHKEY. Stage it in a
+	// 0600 temp file under the (root-only) state dir and pass --auth-key=file:<path>
+	// so the secret never appears in argv or the environment. See issue #31.
+	var authKeyFile string
+	if authKey != "" {
+		stateDir := filepath.Join(DefaultStateDir, tailnetID)
+		f, err := os.CreateTemp(stateDir, "authkey-*")
+		if err != nil {
+			return fmt.Errorf("stage auth key for %s: %w", tailnetID, err)
+		}
+		authKeyFile = f.Name()
+		defer os.Remove(authKeyFile)
+		_ = f.Chmod(0600)
+		if _, err := f.WriteString(authKey); err != nil {
+			f.Close()
+			return fmt.Errorf("write auth key for %s: %w", tailnetID, err)
+		}
+		f.Close()
+	}
+
+	tsArgs := buildTailscaleUpArgs(socketPath, controlURL, authKeyFile)
 	cmdArgs := append([]string{"netns", "exec", nsName}, tsArgs...)
 	cmd := exec.CommandContext(ctx, "ip", cmdArgs...)
-	// Minimal environment for the child process to avoid leaking parent env vars
+	// Minimal environment for the child process to avoid leaking parent env vars.
 	cmd.Env = []string{
 		"PATH=" + os.Getenv("PATH"),
 		"HOME=" + os.Getenv("HOME"),
-		"TS_AUTHKEY=" + authKey,
 	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -44,16 +44,23 @@ func TestSocketPath(t *testing.T) {
 
 func TestBuildTailscaleUpArgs(t *testing.T) {
 	tests := []struct {
-		name       string
-		socketPath string
-		controlURL string
-		wantArgs   []string
+		name        string
+		socketPath  string
+		controlURL  string
+		authKeyFile string
+		wantArgs    []string
 	}{
 		{
-			name:       "no control URL (standard Tailscale)",
+			name:       "no key, no control URL (interactive/browser login)",
 			socketPath: "/tmp/test.sock",
 			controlURL: "",
 			wantArgs:   []string{"tailscale", "--socket=/tmp/test.sock", "up", "--accept-dns=true"},
+		},
+		{
+			name:        "with auth key file",
+			socketPath:  "/tmp/test.sock",
+			authKeyFile: "/var/lib/hydrascale/state/corp/authkey-123",
+			wantArgs:    []string{"tailscale", "--socket=/tmp/test.sock", "up", "--accept-dns=true", "--auth-key=file:/var/lib/hydrascale/state/corp/authkey-123"},
 		},
 		{
 			name:       "with control URL (Headscale)",
@@ -64,7 +71,7 @@ func TestBuildTailscaleUpArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildTailscaleUpArgs(tt.socketPath, tt.controlURL)
+			got := buildTailscaleUpArgs(tt.socketPath, tt.controlURL, tt.authKeyFile)
 			if len(got) != len(tt.wantArgs) {
 				t.Fatalf("buildTailscaleUpArgs() = %v, want %v", got, tt.wantArgs)
 			}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -297,7 +297,20 @@ func (r *Reconciler) executeAction(action Action) error {
 		}
 		return nil
 	case ActionDeleteNS:
-		return r.ns.Delete(action.NsName, r.infraSubnet)
+		if err := r.ns.Delete(action.NsName, r.infraSubnet); err != nil {
+			return err
+		}
+		// Remove the tailnet's state dir (tailscaled state/socket + the #28
+		// overlay upper/work dirs) so `remove` leaves nothing behind — otherwise
+		// stale per-tailnet dirs accumulate under /var/lib/hydrascale/state.
+		// Best-effort; a failure here doesn't fail the teardown. See issue #32.
+		if action.TailnetID != "" {
+			stateDir := filepath.Join(daemon.DefaultStateDir, action.TailnetID)
+			if err := os.RemoveAll(stateDir); err != nil {
+				log.Printf("reconciler: failed to remove state dir %s: %v", stateDir, err)
+			}
+		}
+		return nil
 	case ActionStartDaemon:
 		// Belt-and-braces: ensure the namespace's resolv.conf bind-mount
 		// override exists before tailscaled launches. ActionCreateNS already


### PR DESCRIPTION
Two reliability follow-ups from v0.8.0 testing.

## #31 — namespaced tailscaled left logged-out via `serve`/`apply`

**Root cause (confirmed live + via the CLI):** `AuthorizeDaemon` passed the node auth key only via the `TS_AUTHKEY` environment variable. `tailscale up` reads the key from the **`--auth-key` flag**, *not* `TS_AUTHKEY` (that var is consumed by `tailscaled`/containerboot, not the CLI — `tailscale up --help` never mentions it). So `up` never saw the key, fell back to interactive login, and was killed at the 30s timeout, leaving the tailnet logged-out. `init` masked this with an explicit `--authkey` retry; plain `serve`/`apply` did not.

**Fix:** stage the key in a `0600` temp file under the root-only state dir and pass `--auth-key=file:<path>`. This also keeps the secret out of `argv` (`ps`) and the process environment — more secure than both the old env approach and init's argv retry.

**Verified live:** on a logged-out namespace, the `TS_AUTHKEY` env method falls back to interactive and stays logged out; `--auth-key=file:` authenticates first-try (resuming the same node).

## #32 — state dir not cleaned up on `remove`

`hydrascale remove <id>` tore down the namespace but left `/var/lib/hydrascale/state/<id>/` behind (tailscaled state/socket + the #28 overlay `upper`/`work` dirs), accumulating stale dirs. Best-effort `os.RemoveAll` on `ActionDeleteNS`. **Verified live:** `add` then `remove` now leaves no state dir, with other tailnets untouched.

Tests: new `buildTailscaleUpArgs` case for the auth-key flag; `go build`/`vet`/tests green; both validated end-to-end on x86.
