### PR TITLE
fix: guard state-dir RemoveAll against path traversal

### DIFF
--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -274,6 +274,21 @@ func (r *Reconciler) Apply(actions []Action) {
 	}
 }
 
+// safeStateDir returns the state directory for a tailnet id and whether it is
+// safe to operate on. It guards the root-level state-dir RemoveAll (#32) against
+// path traversal: the id must be a valid tailnet id AND resolve to a direct
+// child of the state dir, so a crafted id (e.g. "..", "a/b") can never escape.
+func safeStateDir(tailnetID string) (string, bool) {
+	if !config.IsValidID(tailnetID) {
+		return "", false
+	}
+	dir := filepath.Join(daemon.DefaultStateDir, tailnetID)
+	if filepath.Dir(dir) != filepath.Clean(daemon.DefaultStateDir) {
+		return "", false
+	}
+	return dir, true
+}
+
 func (r *Reconciler) executeAction(action Action) error {
 	switch action.Type {
 	case ActionCreateNS:
@@ -304,8 +319,11 @@ func (r *Reconciler) executeAction(action Action) error {
 		// overlay upper/work dirs) so `remove` leaves nothing behind — otherwise
 		// stale per-tailnet dirs accumulate under /var/lib/hydrascale/state.
 		// Best-effort; a failure here doesn't fail the teardown. See issue #32.
-		if action.TailnetID != "" {
-			stateDir := filepath.Join(daemon.DefaultStateDir, action.TailnetID)
+		//
+		// The id is derived from a live namespace name (not the IsValidID-
+		// validated config), so validate the path before this root-level
+		// RemoveAll — never let a crafted id (e.g. "..") traverse out.
+		if stateDir, ok := safeStateDir(action.TailnetID); ok {
 			if err := os.RemoveAll(stateDir); err != nil {
 				log.Printf("reconciler: failed to remove state dir %s: %v", stateDir, err)
 			}

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -17,6 +17,26 @@ import (
 	"hydrascale/internal/routing"
 )
 
+func TestSafeStateDir(t *testing.T) {
+	valid := map[string]string{
+		"corp-prod": filepath.Join(daemon.DefaultStateDir, "corp-prod"),
+		"personal":  filepath.Join(daemon.DefaultStateDir, "personal"),
+		"a.b_c-1":   filepath.Join(daemon.DefaultStateDir, "a.b_c-1"),
+	}
+	for id, want := range valid {
+		got, ok := safeStateDir(id)
+		if !ok || got != want {
+			t.Errorf("safeStateDir(%q) = %q,%v; want %q,true", id, got, ok, want)
+		}
+	}
+	// Path-traversal and otherwise-invalid ids must be rejected (never RemoveAll'd).
+	for _, bad := range []string{"", "..", "../etc", "a/b", "foo/../..", ".", "/", "../../root"} {
+		if got, ok := safeStateDir(bad); ok {
+			t.Errorf("safeStateDir(%q) = %q,true; want rejected", bad, got)
+		}
+	}
+}
+
 // --- Mock implementations ---
 
 type mockNS struct {


### PR DESCRIPTION
Follow-up hardening for the #32 state-dir cleanup, flagged by the push security review.

The id used to build the RemoveAll path comes from a live namespace name (`GetTailnetID`), **not** the IsValidID-validated config — so a crafted id could in principle let this **root-level `os.RemoveAll`** escape `/var/lib/hydrascale/state`. Exploitability is near-nil (creating such a namespace already requires root, so it's not an escalation), but a root RemoveAll on an unvalidated path deserves defense in depth.

Adds `safeStateDir()`: requires a valid tailnet id **and** that the resolved path is a direct child of the state dir before removal. Unit-tested against traversal inputs (`..`, `a/b`, `/`, `../../root`, …).