### PR TITLE
feat(api): enrich tailnet detail with peers + MagicDNS, expose host_access

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -359,8 +361,9 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	for i, tn := range cfg.Tailnets {
 		rt := RedactedTailnet{
-			ID:       tn.ID,
-			ExitNode: tn.ExitNode,
+			ID:         tn.ID,
+			ExitNode:   tn.ExitNode,
+			HostAccess: tn.HostAccess,
 		}
 		if tn.AuthKey != "" {
 			rt.AuthKey = "***"
@@ -416,16 +419,31 @@ func (s *Server) handleTailnetDetail(w http.ResponseWriter, r *http.Request) {
 	// FetchedAt stamps when the live data was actually obtained (after the subprocess).
 	resp.FetchedAt = time.Now()
 	resp.TailscaleIPs = status.Self.TailscaleIPs
+	resp.MagicDNSName = strings.TrimSuffix(status.Self.DNSName, ".")
+	resp.MagicDNSSuffix = status.MagicDNSSuffix
 	resp.PeerCount = len(status.Peer)
+	resp.Peers = make([]PeerInfo, 0, len(status.Peer))
 	for _, peer := range status.Peer {
 		if peer.Online {
 			resp.OnlinePeers++
 		}
+		resp.Peers = append(resp.Peers, PeerInfo{
+			HostName:     peer.HostName,
+			DNSName:      strings.TrimSuffix(peer.DNSName, "."),
+			OS:           peer.OS,
+			TailscaleIPs: peer.TailscaleIPs,
+			AllowedIPs:   peer.AllowedIPs,
+			Online:       peer.Online,
+			LastSeen:     peer.LastSeen,
+		})
 	}
+	// Deterministic order: tailscale's Peer map is keyed by node key.
+	sort.Slice(resp.Peers, func(i, j int) bool {
+		return resp.Peers[i].HostName < resp.Peers[j].HostName
+	})
 
 	w.Header().Set("Content-Type", "application/json")
 	if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
 		log.Printf("handleTailnetDetail: encode success response: %v", encErr)
 	}
 }
-

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -417,14 +417,18 @@ func TestReconcileEndpointError(t *testing.T) {
 func TestDetailEndpoint_HappyPath(t *testing.T) {
 	cfgPath := writeTestConfig(t, "alpha")
 	md := newMockDaemon()
+	lastSeen := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	md.statusResult = &daemon.TailscaleStatus{
+		MagicDNSSuffix: "tail1234.ts.net",
 		Self: daemon.StatusNode{
 			TailscaleIPs: []string{"100.64.1.5"},
 			HostName:     "myhost",
+			DNSName:      "myhost.tail1234.ts.net.",
 		},
 		Peer: map[string]daemon.StatusNode{
-			"peer1": {HostName: "peer1", Online: true},
-			"peer2": {HostName: "peer2", Online: false},
+			// Keyed by node key; intentionally out of hostname order to exercise sorting.
+			"nodekeyZ": {HostName: "zeta", DNSName: "zeta.tail1234.ts.net.", OS: "linux", Online: true, TailscaleIPs: []string{"100.64.1.9"}, AllowedIPs: []string{"100.64.1.9/32", "192.168.1.0/24"}, LastSeen: lastSeen},
+			"nodekeyA": {HostName: "alpha-peer", OS: "android", Online: false, TailscaleIPs: []string{"100.64.1.2"}},
 		},
 	}
 	r := reconciler.New(cfgPath, newMockNS(), md, &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
@@ -449,6 +453,70 @@ func TestDetailEndpoint_HappyPath(t *testing.T) {
 	}
 	if detail.FetchedAt.IsZero() {
 		t.Error("FetchedAt should not be zero")
+	}
+	// MagicDNS: self DNSName with trailing dot trimmed, plus suffix.
+	if detail.MagicDNSName != "myhost.tail1234.ts.net" {
+		t.Errorf("MagicDNSName: got %q, want myhost.tail1234.ts.net", detail.MagicDNSName)
+	}
+	if detail.MagicDNSSuffix != "tail1234.ts.net" {
+		t.Errorf("MagicDNSSuffix: got %q, want tail1234.ts.net", detail.MagicDNSSuffix)
+	}
+	// Peers: present, sorted by hostname, with fields carried through.
+	if len(detail.Peers) != 2 {
+		t.Fatalf("Peers: got %d, want 2", len(detail.Peers))
+	}
+	if detail.Peers[0].HostName != "alpha-peer" || detail.Peers[1].HostName != "zeta" {
+		t.Errorf("Peers not sorted by hostname: got %q, %q", detail.Peers[0].HostName, detail.Peers[1].HostName)
+	}
+	zeta := detail.Peers[1]
+	if zeta.OS != "linux" || !zeta.Online || zeta.DNSName != "zeta.tail1234.ts.net" {
+		t.Errorf("zeta peer fields wrong: %+v", zeta)
+	}
+	if len(zeta.AllowedIPs) != 2 || zeta.AllowedIPs[1] != "192.168.1.0/24" {
+		t.Errorf("zeta AllowedIPs: got %v", zeta.AllowedIPs)
+	}
+	if !zeta.LastSeen.Equal(lastSeen) {
+		t.Errorf("zeta LastSeen: got %v, want %v", zeta.LastSeen, lastSeen)
+	}
+}
+
+func TestConfigEndpoint_HostAccess(t *testing.T) {
+	// A config with an explicit host_access flag must surface it via GET /api/config.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := config.DefaultConfig()
+	enabled := true
+	cfg.Tailnets = append(cfg.Tailnets,
+		config.Tailnet{ID: "alpha", HostAccess: &enabled, AuthKey: "tskey-secret"},
+		config.Tailnet{ID: "beta"}, // host_access unset → nil
+	)
+	if err := config.SaveConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	r := reconciler.New(cfgPath, newMockNS(), newMockDaemon(), &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
+	_, client, cleanup := startTestServer(t, r)
+	defer cleanup()
+
+	resp, err := client.GetConfig()
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	byID := map[string]RedactedTailnet{}
+	for _, tn := range resp.Config.Tailnets {
+		byID[tn.ID] = tn
+	}
+	alpha, ok := byID["alpha"]
+	if !ok {
+		t.Fatal("alpha missing from config response")
+	}
+	if alpha.HostAccess == nil || !*alpha.HostAccess {
+		t.Errorf("alpha HostAccess: got %v, want true", alpha.HostAccess)
+	}
+	if alpha.AuthKey != "***" {
+		t.Errorf("alpha AuthKey should be redacted, got %q", alpha.AuthKey)
+	}
+	if byID["beta"].HostAccess != nil {
+		t.Errorf("beta HostAccess should be nil (unset), got %v", *byID["beta"].HostAccess)
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -13,12 +13,12 @@ const DefaultSocketPath = "/var/lib/hydrascale/api.sock"
 
 // StatusResponse is the JSON response for GET /api/status.
 type StatusResponse struct {
-	Desired       map[string]config.Tailnet        `json:"desired"`
+	Desired       map[string]config.Tailnet           `json:"desired"`
 	Actual        map[string]*reconciler.TailnetState `json:"actual"`
-	ErrorStates   map[string]bool                  `json:"error_states"`
-	PausedStates  map[string]bool                  `json:"paused_states"`
-	FailureCounts map[string]int                   `json:"failure_counts"`
-	LastErrors    map[string]string                `json:"last_errors"`
+	ErrorStates   map[string]bool                     `json:"error_states"`
+	PausedStates  map[string]bool                     `json:"paused_states"`
+	FailureCounts map[string]int                      `json:"failure_counts"`
+	LastErrors    map[string]string                   `json:"last_errors"`
 }
 
 // EventsResponse is the JSON response for GET /api/events.
@@ -47,9 +47,10 @@ type DNSConfigRequest struct {
 
 // RedactedTailnet is a Tailnet with the auth key hidden.
 type RedactedTailnet struct {
-	ID       string `json:"id"`
-	ExitNode string `json:"exit_node,omitempty"`
-	AuthKey  string `json:"auth_key,omitempty"`
+	ID         string `json:"id"`
+	ExitNode   string `json:"exit_node,omitempty"`
+	AuthKey    string `json:"auth_key,omitempty"`
+	HostAccess *bool  `json:"host_access,omitempty"`
 }
 
 // RedactedConfig mirrors config.Config but with auth keys redacted.
@@ -64,15 +65,29 @@ type ConfigResponse struct {
 	Config RedactedConfig `json:"config"`
 }
 
+// PeerInfo is a single peer within a tailnet, derived from tailscale status --json.
+type PeerInfo struct {
+	HostName     string    `json:"host_name"`
+	DNSName      string    `json:"dns_name,omitempty"`
+	OS           string    `json:"os,omitempty"`
+	TailscaleIPs []string  `json:"tailscale_ips,omitempty"`
+	AllowedIPs   []string  `json:"allowed_ips,omitempty"`
+	Online       bool      `json:"online"`
+	LastSeen     time.Time `json:"last_seen,omitempty"`
+}
+
 // TailnetDetailResponse is the JSON response for GET /api/tailnet/{id}/detail.
 // It contains live data fetched from inside the tailnet's network namespace.
-// Routes and config fields (ExitNode, HostAccess) are NOT included here —
-// the TUI assembles those from the background status poll (m.status).
-// Error is set (with HTTP 200) when the live fetch fails; the TUI renders it inline.
+// Config fields (ExitNode, HostAccess) and reconciler route state are NOT included
+// here — clients assemble those from GET /api/status and GET /api/config.
+// Error is set (with HTTP 200) when the live fetch fails; clients render it inline.
 type TailnetDetailResponse struct {
-	TailscaleIPs []string  `json:"tailscale_ips"`
-	PeerCount    int       `json:"peer_count"`
-	OnlinePeers  int       `json:"online_peers"`
-	FetchedAt    time.Time `json:"fetched_at"`
-	Error        string    `json:"error,omitempty"`
+	TailscaleIPs   []string   `json:"tailscale_ips"`
+	MagicDNSName   string     `json:"magic_dns_name,omitempty"`
+	MagicDNSSuffix string     `json:"magic_dns_suffix,omitempty"`
+	PeerCount      int        `json:"peer_count"`
+	OnlinePeers    int        `json:"online_peers"`
+	Peers          []PeerInfo `json:"peers,omitempty"`
+	FetchedAt      time.Time  `json:"fetched_at"`
+	Error          string     `json:"error,omitempty"`
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,10 +26,13 @@ type TailscaleStatus struct {
 
 // StatusNode represents a node in tailscale status.
 type StatusNode struct {
-	HostName     string   `json:"HostName"`
-	DNSName      string   `json:"DNSName"`
-	TailscaleIPs []string `json:"TailscaleIPs"`
-	Online       bool     `json:"Online"`
+	HostName     string    `json:"HostName"`
+	DNSName      string    `json:"DNSName"`
+	OS           string    `json:"OS"`
+	TailscaleIPs []string  `json:"TailscaleIPs"`
+	AllowedIPs   []string  `json:"AllowedIPs"`
+	Online       bool      `json:"Online"`
+	LastSeen     time.Time `json:"LastSeen"`
 }
 
 // Manager defines the interface for daemon lifecycle operations.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func TestStartDaemon(t *testing.T) {
@@ -18,7 +20,6 @@ func TestStopDaemon(t *testing.T) {
 func TestCheckHealth(t *testing.T) {
 	t.Skip("Skipping health check test - requires privileges and tailscaled")
 }
-
 
 func TestValidatePID(t *testing.T) {
 	// Our own process should be findable in /proc
@@ -84,6 +85,39 @@ func TestBuildTailscaleUpArgs(t *testing.T) {
 	}
 }
 
+func TestStatusNode_ParsesPeerFields(t *testing.T) {
+	// A trimmed sample of `tailscale status --json`. The GUI peers table needs
+	// OS, LastSeen and AllowedIPs parsed off each node, so guard the JSON tags.
+	raw := `{
+		"MagicDNSSuffix": "tail1234.ts.net",
+		"Self": {"HostName": "myhost", "DNSName": "myhost.tail1234.ts.net.", "OS": "linux", "TailscaleIPs": ["100.64.1.5"], "Online": true},
+		"Peer": {
+			"nodekey:abc": {"HostName": "orin", "DNSName": "orin.tail1234.ts.net.", "OS": "linux", "TailscaleIPs": ["100.64.1.9"], "AllowedIPs": ["100.64.1.9/32", "192.168.1.0/24"], "Online": true, "LastSeen": "2026-07-01T12:00:00Z"}
+		}
+	}`
+	var st TailscaleStatus
+	if err := json.Unmarshal([]byte(raw), &st); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if st.MagicDNSSuffix != "tail1234.ts.net" {
+		t.Errorf("MagicDNSSuffix: got %q", st.MagicDNSSuffix)
+	}
+	p, ok := st.Peer["nodekey:abc"]
+	if !ok {
+		t.Fatal("peer nodekey:abc missing")
+	}
+	if p.OS != "linux" {
+		t.Errorf("OS: got %q, want linux", p.OS)
+	}
+	if len(p.AllowedIPs) != 2 || p.AllowedIPs[1] != "192.168.1.0/24" {
+		t.Errorf("AllowedIPs: got %v", p.AllowedIPs)
+	}
+	want := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	if !p.LastSeen.Equal(want) {
+		t.Errorf("LastSeen: got %v, want %v", p.LastSeen, want)
+	}
+}
+
 func TestStopDaemon_StalePID(t *testing.T) {
 	// Create a temp state dir with a stale PID file
 	dir := t.TempDir()
@@ -104,4 +138,3 @@ func TestStopDaemon_StalePID(t *testing.T) {
 		t.Error("stale PID should not validate")
 	}
 }
-


### PR DESCRIPTION
## What

Milestone 1 (backend) of the cross-platform GUI (#34). Read-only enrichment of the control API to surface data the daemon **already fetches** from `tailscale status --json` but currently discards before serialization.

## Why

The planned GUI detail view needs a peers table (name / OS / routes / last-seen), the tailnet's MagicDNS name, and its host-access state. None of that reached clients today — `handleTailnetDetail` kept only IPs + peer counts, and `StatusNode` didn't even parse OS/LastSeen/AllowedIPs.

## Changes

- **`StatusNode`**: parse `OS`, `LastSeen`, `AllowedIPs` off each node (free from the existing JSON unmarshal).
- **`TailnetDetailResponse`**: add `MagicDNSName` (trailing dot trimmed), `MagicDNSSuffix`, and `Peers []PeerInfo` (sorted by hostname for deterministic output).
- **`RedactedTailnet`**: expose `HostAccess` via `GET /api/config` (auth key stays redacted).
- Fixed the now-stale doc comment on `TailnetDetailResponse`.

## Scope

Read path only. The write path (letting `add`/config set control URL, host-access, DNS-accept — the wizard's needs) is a follow-up PR. No new dependencies. The existing TUI keeps building; it can adopt the new fields later.

## Test

`go build ./...`, `go vet ./...`, and `go test ./...` all green on Linux (phobos, go1.26). New tests: peer + MagicDNS assertions in the detail happy-path, `host_access` exposure via `/api/config`, and a `tailscale status --json` parse guard for the new `StatusNode` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)