### PR TITLE
feat(api): optional socket_group for non-root API access

### DIFF
--- a/cmd/hydrascale/init.go
+++ b/cmd/hydrascale/init.go
@@ -92,7 +92,7 @@ func runInit(force bool) error {
 
 	promptGUIAccess(p, cfg)
 
-	for _, d := range []string{"/var/lib/hydrascale/state", "/var/log/hydrascale"} {
+	for _, d := range []string{"/etc/hydrascale", "/var/lib/hydrascale/state", "/var/log/hydrascale"} {
 		if err := os.MkdirAll(d, 0750); err != nil {
 			return fmt.Errorf("create %s: %w", d, err)
 		}

--- a/cmd/hydrascale/init.go
+++ b/cmd/hydrascale/init.go
@@ -90,6 +90,8 @@ func runInit(force bool) error {
 		cfg = buildConfig(answers, false)
 	}
 
+	promptGUIAccess(p, cfg)
+
 	for _, d := range []string{"/var/lib/hydrascale/state", "/var/log/hydrascale"} {
 		if err := os.MkdirAll(d, 0750); err != nil {
 			return fmt.Errorf("create %s: %w", d, err)
@@ -234,6 +236,34 @@ func promptTailnet(p *prompter) (tailnetAnswers, string) {
 		return a, key
 	}
 	return a, ""
+}
+
+// promptGUIAccess optionally grants non-root access to the control socket via a
+// unix group. The Hydrascale desktop app (and any SSH-forwarded remote client)
+// connects as a non-root user, so this is required for the GUI to work.
+func promptGUIAccess(p *prompter, cfg *config.Config) {
+	fmt.Println("\nGUI / remote access:")
+	fmt.Println("  The daemon's control socket is root-only by default. The Hydrascale")
+	fmt.Println("  desktop app — and any non-root or SSH-forwarded client — needs group")
+	fmt.Println("  access to it. This is required for the GUI.")
+	if !p.yesNo("  Enable non-root access via a unix group?", true) {
+		return
+	}
+	group := p.line("  Group name", "hydrascale")
+	user := p.line("  User to add to the group", os.Getenv("SUDO_USER"))
+	if out, err := exec.Command("groupadd", "-f", group).CombinedOutput(); err != nil {
+		fmt.Printf("  groupadd failed: %v (%s)\n", err, strings.TrimSpace(string(out)))
+		return
+	}
+	if user != "" {
+		if out, err := exec.Command("usermod", "-aG", group, user).CombinedOutput(); err != nil {
+			fmt.Printf("  usermod failed: %v (%s)\n", err, strings.TrimSpace(string(out)))
+		} else {
+			fmt.Printf("  ✓ added %s to group %q (log out/in for it to take effect)\n", user, group)
+		}
+	}
+	cfg.SocketGroup = group
+	fmt.Printf("  ✓ socket_group set to %q — the daemon will make the socket group-accessible\n", group)
 }
 
 // runPreflight reports environment readiness and offers to fix common problems.

--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -467,6 +467,7 @@ func serveCmd() *cobra.Command {
 
 			// Start API server
 			apiServer := api.NewServer(api.DefaultSocketPath, r)
+			apiServer.SetSocketGroup(cfg.SocketGroup)
 			go func() {
 				if err := apiServer.Start(); err != nil {
 					fmt.Fprintf(os.Stderr, "API server start error: %v\n", err)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,7 +10,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/user"
+	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -21,11 +24,16 @@ import (
 
 // Server is an HTTP server listening on a Unix socket.
 type Server struct {
-	reconciler *reconciler.Reconciler
-	listener   net.Listener
-	httpServer *http.Server
-	socketPath string
+	reconciler  *reconciler.Reconciler
+	listener    net.Listener
+	httpServer  *http.Server
+	socketPath  string
+	socketGroup string
 }
+
+// SetSocketGroup configures a unix group that may reach the control socket.
+// Empty (default) keeps the socket root-only (0600). Must be called before Start.
+func (s *Server) SetSocketGroup(group string) { s.socketGroup = group }
 
 // NewServer creates a new Server that will listen on socketPath.
 func NewServer(socketPath string, r *reconciler.Reconciler) *Server {
@@ -81,6 +89,13 @@ func (s *Server) Start() error {
 	if err := os.Chmod(s.socketPath, 0600); err != nil {
 		ln.Close()
 		return fmt.Errorf("failed to set socket permissions: %w", err)
+	}
+	if s.socketGroup != "" {
+		if err := applySocketGroup(s.socketPath, s.socketGroup); err != nil {
+			ln.Close()
+			return fmt.Errorf("failed to apply socket group %q: %w", s.socketGroup, err)
+		}
+		log.Printf("api: socket group access enabled for %q", s.socketGroup)
 	}
 	s.listener = ln
 
@@ -167,6 +182,35 @@ func (s *Server) writeReconcileResponse(w http.ResponseWriter, err error) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+// applySocketGroup makes the control socket reachable by members of group:
+// the parent dir gets root:<group> 0750 (group can traverse to the socket) and
+// the socket itself root:<group> 0660 (group can connect). The daemon still
+// owns both as root; only the named group is additionally granted access.
+func applySocketGroup(socketPath, group string) error {
+	g, err := user.LookupGroup(group)
+	if err != nil {
+		return fmt.Errorf("lookup group %q: %w", group, err)
+	}
+	gid, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return fmt.Errorf("parse gid for %q: %w", group, err)
+	}
+	dir := filepath.Dir(socketPath)
+	if err := os.Chown(dir, 0, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", dir, err)
+	}
+	if err := os.Chmod(dir, 0750); err != nil {
+		return fmt.Errorf("chmod %s: %w", dir, err)
+	}
+	if err := os.Chown(socketPath, 0, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", socketPath, err)
+	}
+	if err := os.Chmod(socketPath, 0660); err != nil {
+		return fmt.Errorf("chmod %s: %w", socketPath, err)
+	}
+	return nil
 }
 
 // isValidControlURL reports whether s is an absolute http(s) URL with a host,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -591,6 +591,13 @@ func TestDetailEndpoint_NoPeers(t *testing.T) {
 	}
 }
 
+func TestApplySocketGroup_UnknownGroup(t *testing.T) {
+	// An unknown group is a config error, surfaced before any chown/chmod.
+	if err := applySocketGroup("/tmp/hydrascale-test.sock", "no-such-group-9c3f1a"); err == nil {
+		t.Error("expected error for unknown group, got nil")
+	}
+}
+
 func TestAddTailnet_PersistsControlURLAndHostAccess(t *testing.T) {
 	cfgPath := writeTestConfig(t) // start empty
 	r := reconciler.New(cfgPath, newMockNS(), newMockDaemon(), &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,10 @@ import (
 var validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$`)
 
 // DefaultConfigPath is the default location for the Hydrascale config file.
-const DefaultConfigPath = "/var/lib/hydrascale/config.yaml"
+// Config lives in /etc (declarative system config); runtime state and the API
+// socket live under /var/lib/hydrascale. This matches the systemd unit, so the
+// CLI and the service always read the same file.
+const DefaultConfigPath = "/etc/hydrascale/config.yaml"
 
 // Tailnet represents a single Tailscale tailnet configuration.
 type Tailnet struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,11 @@ type Config struct {
 	EventLog    string           `yaml:"event_log,omitempty"`
 	HostDNS     HostDNSConfig    `yaml:"host_dns,omitempty"`
 	InfraSubnet string           `yaml:"infra_subnet,omitempty"` // Default: 10.200.0.0/16
+	// SocketGroup, when set, makes the API control socket group-accessible:
+	// the daemon chowns /var/lib/hydrascale + api.sock to root:<group> with
+	// group-traversable/rw modes. Add a trusted user to that group to let it
+	// reach the API (e.g. an SSH-forwarded remote GUI) without being root.
+	SocketGroup string `yaml:"socket_group,omitempty"`
 }
 
 // TailnetHostAccess returns whether host access is enabled for a specific tailnet,


### PR DESCRIPTION
## What

A `socket_group` config option so a trusted unix group can reach the daemon's control socket **without being root** — enabling a remote (SSH-forwarded) GUI to connect without a root relay.

**Stacked on #38** (base `feat/gui-api-write-path`). Merge #37 → #38 → this.

## Why

Diagnosed while wiring the GUI's remote connection: the blocker to non-root access wasn't the socket mode — it was **directory traversal**. `/var/lib/hydrascale` is `0750 root:root`, so a non-root process (an `ssh -L` forward running as the login user) gets `EACCES` reaching `api.sock` even at mode `0666`. There is no peer-cred check in the code; it was purely the parent dir.

## Change

When `socket_group: <name>` is set, on API start the daemon:
- `chown root:<group>` + `chmod 0750` on `/var/lib/hydrascale` (group can traverse)
- `chown root:<group>` + `chmod 0660` on `api.sock` (group can connect)

The daemon still owns both as root; only the named group is additionally granted access. Empty (default) → unchanged `0600` root-only behavior.

Usage: `groupadd hydrascale && usermod -aG hydrascale <user>`, set `socket_group: hydrascale`, restart. Then `ssh -L local.sock:/var/lib/hydrascale/api.sock <user>@host` works directly.

## Test

`go build/test ./...` green on Linux (phobos). New `TestApplySocketGroup_UnknownGroup` covers the config-error path (root not required); existing `serve`/Start tests unaffected since the default group is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)