### PR TITLE
feat(api): let tailnet add set control URL and host access

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -121,9 +121,10 @@ func (c *Client) postJSON(path string, body interface{}, result interface{}) err
 	return nil
 }
 
-// AddTailnet calls POST /api/tailnet/add.
-func (c *Client) AddTailnet(id, authKey, exitNode string) (*ReconcileResponse, error) {
-	req := TailnetRequest{ID: id, AuthKey: authKey, ExitNode: exitNode}
+// AddTailnet calls POST /api/tailnet/add. The request carries the full tailnet
+// spec (id, auth key, exit node, control URL, host access); zero-value fields
+// are omitted from the JSON body.
+func (c *Client) AddTailnet(req TailnetRequest) (*ReconcileResponse, error) {
 	var result ReconcileResponse
 	if err := c.postJSON("/api/tailnet/add", req, &result); err != nil {
 		return nil, err

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -168,6 +169,16 @@ func (s *Server) writeReconcileResponse(w http.ResponseWriter, err error) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+// isValidControlURL reports whether s is an absolute http(s) URL with a host,
+// as required for a Headscale/custom coordination server (--login-server).
+func isValidControlURL(s string) bool {
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
 func (s *Server) handleTailnetAdd(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -182,6 +193,10 @@ func (s *Server) handleTailnetAdd(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ID == "" {
 		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+	if req.ControlURL != "" && !isValidControlURL(req.ControlURL) {
+		http.Error(w, "control_url must be an absolute http(s) URL", http.StatusBadRequest)
 		return
 	}
 
@@ -200,9 +215,11 @@ func (s *Server) handleTailnetAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg.Tailnets = append(cfg.Tailnets, config.Tailnet{
-		ID:       req.ID,
-		AuthKey:  req.AuthKey,
-		ExitNode: req.ExitNode,
+		ID:         req.ID,
+		AuthKey:    req.AuthKey,
+		ExitNode:   req.ExitNode,
+		ControlURL: req.ControlURL,
+		HostAccess: req.HostAccess,
 	})
 
 	if err := config.SaveConfig(cfgPath, cfg); err != nil {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -591,6 +591,65 @@ func TestDetailEndpoint_NoPeers(t *testing.T) {
 	}
 }
 
+func TestAddTailnet_PersistsControlURLAndHostAccess(t *testing.T) {
+	cfgPath := writeTestConfig(t) // start empty
+	r := reconciler.New(cfgPath, newMockNS(), newMockDaemon(), &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
+	_, client, cleanup := startTestServer(t, r)
+	defer cleanup()
+
+	enabled := true
+	if _, err := client.AddTailnet(TailnetRequest{
+		ID:         "gamma",
+		AuthKey:    "tskey-secret",
+		ControlURL: "https://headscale.example.com",
+		HostAccess: &enabled,
+	}); err != nil {
+		t.Fatalf("AddTailnet: %v", err)
+	}
+
+	// The reconcile outcome is orthogonal; assert the config file persisted the fields.
+	cfg, err := config.LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	var gamma *config.Tailnet
+	for i := range cfg.Tailnets {
+		if cfg.Tailnets[i].ID == "gamma" {
+			gamma = &cfg.Tailnets[i]
+		}
+	}
+	if gamma == nil {
+		t.Fatal("gamma not persisted")
+	}
+	if gamma.ControlURL != "https://headscale.example.com" {
+		t.Errorf("ControlURL: got %q", gamma.ControlURL)
+	}
+	if gamma.HostAccess == nil || !*gamma.HostAccess {
+		t.Errorf("HostAccess: got %v, want true", gamma.HostAccess)
+	}
+}
+
+func TestAddTailnet_RejectsInvalidControlURL(t *testing.T) {
+	cfgPath := writeTestConfig(t)
+	r := reconciler.New(cfgPath, newMockNS(), newMockDaemon(), &mockRouting{}, 1*time.Second, nil, "10.200.0.0/16")
+	_, client, cleanup := startTestServer(t, r)
+	defer cleanup()
+
+	if _, err := client.AddTailnet(TailnetRequest{ID: "gamma", ControlURL: "not-a-url"}); err == nil {
+		t.Fatal("expected error for invalid control_url, got nil")
+	}
+	// Nothing should have been persisted on a rejected request.
+	cfg, err := config.LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	for _, tn := range cfg.Tailnets {
+		if tn.ID == "gamma" {
+			t.Error("gamma should not have been persisted on invalid control_url")
+		}
+	}
+}
+
 // TestTailnetDetailClient_HTTP500 verifies that Client.TailnetDetail returns an
 // error when the server responds with a non-200, non-404 status code.
 func TestTailnetDetailClient_HTTP500(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -34,9 +34,11 @@ type ReconcileResponse struct {
 
 // TailnetRequest is the request body for tailnet management endpoints.
 type TailnetRequest struct {
-	ID       string `json:"id"`
-	AuthKey  string `json:"auth_key,omitempty"`
-	ExitNode string `json:"exit_node,omitempty"`
+	ID         string `json:"id"`
+	AuthKey    string `json:"auth_key,omitempty"`
+	ExitNode   string `json:"exit_node,omitempty"`
+	ControlURL string `json:"control_url,omitempty"`
+	HostAccess *bool  `json:"host_access,omitempty"`
 }
 
 // DNSConfigRequest is the request body for POST /api/config/dns.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -202,7 +202,7 @@ func triggerReconcile(c *api.Client) tea.Cmd {
 
 func doAddTailnet(c *api.Client, id, authKey, exitNode string) tea.Cmd {
 	return func() tea.Msg {
-		resp, err := c.AddTailnet(id, authKey, exitNode)
+		resp, err := c.AddTailnet(api.TailnetRequest{ID: id, AuthKey: authKey, ExitNode: exitNode})
 		if err != nil {
 			return mutationMsg{err: err}
 		}
@@ -994,4 +994,3 @@ func truncateVisible(s string, maxWidth int) string {
 	}
 	return s
 }
-


### PR DESCRIPTION
Write-path enrichment (was #38, recreated after the stacked base merged). Lets the GUI wizard create tailnets with a control URL + host access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)