### PR TITLE
feat: embed version and surface it to the GUI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
 
 archives:
   - id: default

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@
 - [Requirements](#requirements)
 - [Install](#install)
 - [Quick Start](#quick-start)
+- [Desktop GUI](#desktop-gui)
 - [Uninstall](#uninstall)
 - [Host Access](#host-access) -- transparent access to all tailnet peers from the host
 - [Headscale / Custom Control Server](#headscale--custom-control-server)
 - [Config Reference](#config-reference)
+- [Remote / GUI access](#remote--gui-access)
 - [Networking](#networking)
 - [CLI Commands](#cli-commands)
 - [Environment Variables](#environment-variables)
@@ -83,7 +85,7 @@ sudo hydrascale init
 
 To configure manually instead:
 
-1. Create a config file at `/var/lib/hydrascale/config.yaml`:
+1. Create a config file at `/etc/hydrascale/config.yaml`:
 
 ```yaml
 version: 2
@@ -109,6 +111,48 @@ sudo hydrascale apply
 ```bash
 sudo hydrascale serve
 ```
+
+## Desktop GUI
+
+Hydrascale ships a cross-platform desktop app (macOS, Windows, Linux) for managing
+your tailnets visually: a live dashboard, per-tailnet detail with peers, an
+add-tailnet wizard, and remove. Because the daemon is Linux-only, the app is a
+**remote client** — it talks to the daemon's control API and runs on any OS.
+
+> **No system tray yet.** The app is a normal window; closing it quits it (and drops
+> its SSH tunnel). A menu-bar / system-tray presence with close-to-background is
+> planned for a future **Wails v3 migration** — Wails v2 (what the app is built on)
+> has no built-in tray, so it's deliberately deferred rather than hacked in.
+
+### Download
+
+Grab the app for your OS from the [Releases](https://github.com/Crank-Git/Hydrascale/releases)
+page — `Hydrascale.app` (macOS), `.exe` (Windows), or the Linux binary. On macOS the app
+is currently unsigned; right-click → **Open** the first time to get past Gatekeeper.
+
+### Build from source
+
+The GUI is a separate Go module under `gui/`, built with [Wails](https://wails.io) v2
+(needs the Wails CLI and its platform deps — run `wails doctor`):
+
+```bash
+cd gui
+wails build      # → build/bin/ (.app / .exe / binary)
+# or: wails dev  # hot-reload dev window
+```
+
+### Connecting
+
+Open **Settings** (the gear in the sidebar) and point the app at your daemon:
+
+- **Local** — app on the same Linux host as the daemon: leave *SSH host* blank, socket
+  path `/var/lib/hydrascale/api.sock`.
+- **Remote** — app on your Mac/Windows/another box: set *SSH host* (`user@host`) and the
+  daemon socket path. The app forwards the socket over SSH.
+
+The statusbar shows the version of the **daemon it's connected to**. Remote access
+requires a non-root path to the control socket — see
+[Remote / GUI access](#remote--gui-access).
 
 ## Uninstall
 
@@ -305,6 +349,12 @@ host_access: false
 # Must be an IPv4 CIDR of at least /16.
 # infra_subnet: "10.200.0.0/16"
 
+# Unix group granted access to the control socket (default: empty = root-only).
+# Required for the desktop GUI and any non-root or SSH-forwarded client. When set,
+# the daemon makes /var/lib/hydrascale and api.sock group-accessible; add your user
+# to this group. See "Remote / GUI access" below.
+# socket_group: hydrascale
+
 # List of tailnets to manage
 tailnets:
   - id: "corp-prod"              # unique identifier (alphanumeric, dots, hyphens, underscores; max 63 chars)
@@ -326,6 +376,34 @@ host_dns:
 # Reconciler settings
 reconciler:
   interval: 10s                  # how often the control loop runs (Go duration)
+```
+
+## Remote / GUI access
+
+The daemon's control socket (`/var/lib/hydrascale/api.sock`) is **root-only by
+default** — mode `0600`, and `/var/lib/hydrascale` isn't traversable by other users.
+The desktop GUI, and any non-root or SSH-forwarded client, needs group access.
+
+Set `socket_group` and add your user to it:
+
+```bash
+sudo groupadd hydrascale
+sudo usermod -aG hydrascale "$USER"    # log out/in for it to take effect
+# set `socket_group: hydrascale` in the config, then restart the daemon
+```
+
+`hydrascale init` offers this as a step. Once set, the daemon owns the socket
+`root:hydrascale 0660` and makes the directory group-traversable, so group members
+reach the API without being root.
+
+**Remote (GUI on another machine):** in the app's Settings, set the **SSH host**
+(`user@linux-host`) and socket path — the GUI forwards the socket over SSH for you.
+The forward connects as your SSH user, which must be in the socket group on the host.
+For non-GUI clients, forward it yourself:
+
+```bash
+ssh -L /tmp/hydrascale.sock:/var/lib/hydrascale/api.sock user@linux-host
+curl --unix-socket /tmp/hydrascale.sock http://unix/api/status
 ```
 
 ## Networking

--- a/cmd/hydrascale/main.go
+++ b/cmd/hydrascale/main.go
@@ -27,6 +27,10 @@ import (
 
 var cfgFile string
 
+// version is the Hydrascale version, injected at release time via
+// -ldflags "-X main.version=<tag>". "dev" for source/local builds.
+var version = "dev"
+
 // systemdUnit is the canonical content of /etc/systemd/system/hydrascale.service
 // written by `hydrascale install`. Must stay byte-identical to
 // contrib/hydrascale.service — enforced by TestSystemdUnitMatchesContrib.
@@ -36,8 +40,9 @@ var systemdUnit string
 
 func main() {
 	var rootCmd = &cobra.Command{
-		Use:   "hydrascale",
-		Short: "Hydrascale - Run multiple Tailscale tailnets simultaneously",
+		Use:     "hydrascale",
+		Version: version,
+		Short:   "Hydrascale - Run multiple Tailscale tailnets simultaneously",
 		Long: `Hydrascale is a Linux-only Go service that lets a single user run
 multiple Tailscale tailnets simultaneously by using network namespaces for isolation.
 
@@ -69,10 +74,21 @@ reconciles toward it. GitOps for tailnets.`,
 	rootCmd.AddCommand(envCmd())
 	rootCmd.AddCommand(installCmd())
 	rootCmd.AddCommand(uninstallCmd())
+	rootCmd.AddCommand(versionCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+}
+
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the Hydrascale version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("hydrascale", version)
+		},
 	}
 }
 
@@ -468,6 +484,7 @@ func serveCmd() *cobra.Command {
 			// Start API server
 			apiServer := api.NewServer(api.DefaultSocketPath, r)
 			apiServer.SetSocketGroup(cfg.SocketGroup)
+			apiServer.SetVersion(version)
 			go func() {
 				if err := apiServer.Start(); err != nil {
 					fmt.Fprintf(os.Stderr, "API server start error: %v\n", err)

--- a/gui/frontend/dist/index.html
+++ b/gui/frontend/dist/index.html
@@ -750,7 +750,7 @@ body { margin:0; }
           '<span>reconcile ' + m.reconcileSec + 's</span>' +
           '<span>host ' + esc(d.host) + '</span>' +
           '<span style="margin-left:auto">' + d.tailnets.length + ' tailnets · ' + m.peers + ' peers</span>' +
-          '<span>hydrascale ' + esc(d.version) + '</span>';
+          '<span>hydrascale' + (d.version ? ' ' + esc(d.version) : '') + '</span>';
       }
       // Rebound rows: fetch + render the detail view from Go on click.
       Array.prototype.forEach.call(document.querySelectorAll('#v-list .tbl tbody tr'), function (tr) {

--- a/gui/socketsource.go
+++ b/gui/socketsource.go
@@ -82,8 +82,9 @@ type apiConfig struct {
 }
 
 type apiStatus struct {
-	ErrorStates  map[string]bool `json:"error_states"`
-	PausedStates map[string]bool `json:"paused_states"`
+	ServerVersion string          `json:"server_version"`
+	ErrorStates   map[string]bool `json:"error_states"`
+	PausedStates  map[string]bool `json:"paused_states"`
 	// Actual/TailnetState is marshaled with Go field names (no json tags).
 	Actual map[string]struct {
 		NsName        string `json:"NsName"`
@@ -190,7 +191,7 @@ func (s *socketSource) Dashboard() (Dashboard, error) {
 		Host:    hostName(st),
 		Healthy: healthy,
 		DNSOK:   true,
-		Version: "",
+		Version: st.ServerVersion,
 		Metrics: Metrics{
 			Tailnets: len(rows), Reconnecting: reconnecting, Peers: peersTotal,
 			HostAccessOn: haOn, ReconcileSec: 10, Uptime: "",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,11 +29,15 @@ type Server struct {
 	httpServer  *http.Server
 	socketPath  string
 	socketGroup string
+	version     string
 }
 
 // SetSocketGroup configures a unix group that may reach the control socket.
 // Empty (default) keeps the socket root-only (0600). Must be called before Start.
 func (s *Server) SetSocketGroup(group string) { s.socketGroup = group }
+
+// SetVersion records the daemon version, surfaced to clients via /api/status.
+func (s *Server) SetVersion(v string) { s.version = v }
 
 // NewServer creates a new Server that will listen on socketPath.
 func NewServer(socketPath string, r *reconciler.Reconciler) *Server {
@@ -148,6 +152,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		PausedStates:  s.reconciler.PausedStates(),
 		FailureCounts: s.reconciler.FailureCounts(),
 		LastErrors:    s.reconciler.LastErrors(),
+		ServerVersion: s.version,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -19,6 +19,7 @@ type StatusResponse struct {
 	PausedStates  map[string]bool                     `json:"paused_states"`
 	FailureCounts map[string]int                      `json:"failure_counts"`
 	LastErrors    map[string]string                   `json:"last_errors"`
+	ServerVersion string                              `json:"server_version,omitempty"`
 }
 
 // EventsResponse is the JSON response for GET /api/events.


### PR DESCRIPTION
The daemon carried no version (goreleaser only stripped symbols), so the GUI statusbar was blank on the live path.

- `main.version` injected at release via `-ldflags -X main.version={{.Version}}`; `hydrascale version` / `--version` print it; `dev` for source builds
- daemon exposes it via `GET /api/status` (`server_version`)
- the GUI reads `server_version` and shows the **daemon's** version in the statusbar — so the app reflects whatever daemon it's connected to

This makes the release's daemon + GUI versions consistent (both built from the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)