### PR TITLE
ci: build the desktop GUI per-OS and attach it to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,17 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual trigger to test-build the GUI on all OSes without cutting a release
+  # (the daemon/goreleaser job and asset uploads only run on a tag).
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
+  # Daemon: goreleaser builds the Linux binaries and creates the GitHub Release.
   release:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,5 +33,82 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # GUI: build the Wails desktop app per-OS and attach it to the release.
+  gui:
+    # Runs after the release exists (on tag); on workflow_dispatch it builds
+    # without a release job to satisfy (the upload step is tag-gated below).
+    needs: [release]
+    if: always() && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: darwin/universal
+          - os: windows-latest
+            platform: windows/amd64
+          - os: ubuntu-latest
+            platform: linux/amd64
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: gui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Linux WebKit deps
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+
+      - name: Install Wails CLI
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.13.0
+
+      - name: Build (Linux — WebKit 4.1 tag)
+        if: matrix.os == 'ubuntu-latest'
+        run: wails build -platform ${{ matrix.platform }} -tags webkit2_41 -ldflags "-X main.appVersion=${{ github.ref_name }}"
+
+      - name: Build (macOS / Windows)
+        if: matrix.os != 'ubuntu-latest'
+        run: wails build -platform ${{ matrix.platform }} -ldflags "-X main.appVersion=${{ github.ref_name }}"
+
+      - name: Package (macOS)
+        if: matrix.os == 'macos-latest'
+        run: ditto -c -k --keepParent build/bin/Hydrascale.app "Hydrascale_${{ github.ref_name }}_macos.zip"
+
+      - name: Package (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: tar czf "Hydrascale_${{ github.ref_name }}_linux_amd64.tar.gz" -C build/bin Hydrascale
+
+      - name: Package (Windows)
+        if: matrix.os == 'windows-latest'
+        run: Copy-Item build/bin/Hydrascale.exe "Hydrascale_${{ github.ref_name }}_windows_amd64.exe"
+        shell: pwsh
+
+      # Always upload as a workflow artifact (lets workflow_dispatch verify builds).
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-${{ matrix.os }}
+          path: gui/Hydrascale_*
+          if-no-files-found: error
+
+      # Attach to the GitHub Release only on a tag.
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: gh release upload "${{ github.ref_name }}" Hydrascale_* --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gui/main.go
+++ b/gui/main.go
@@ -12,6 +12,11 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
+// appVersion is this app's own version, injected at release via
+// -ldflags "-X main.appVersion=<tag>". "dev" for local builds. (The statusbar
+// separately shows the version of the daemon it's connected to.)
+var appVersion = "dev"
+
 func main() {
 	// Connection comes from persisted settings (Settings modal), overridable by
 	// the HYDRASCALE_SOCKET env var. Defaults to the built-in mock so the app
@@ -35,7 +40,7 @@ func main() {
 			TitleBar: mac.TitleBarHiddenInset(),
 			About: &mac.AboutInfo{
 				Title:   "Hydrascale",
-				Message: "Manage multiple Tailscale tailnets.",
+				Message: "Manage multiple Tailscale tailnets.\nVersion " + appVersion,
 			},
 		},
 	})


### PR DESCRIPTION
Extends the release workflow so releases include the **desktop GUI**, not just the daemon.

- On a **tag**: goreleaser builds the daemon + creates the release (unchanged), then a matrix (**macOS / Windows / Linux**) builds the Wails app and attaches `Hydrascale_<tag>_{macos.zip,windows_amd64.exe,linux_amd64.tar.gz}`.
- GUI carries its own version via `-ldflags -X main.appVersion` (shown in the macOS About box); the statusbar still shows the *daemon's* version.
- **`workflow_dispatch`** builds all three OSes and uploads them as workflow artifacts (release upload is tag-gated) — so the per-OS Wails build can be smoke-tested **without** cutting a release.

## Next step after merge
Trigger the workflow manually (`gh workflow run release.yml` on main) to confirm the GUI builds green on all three runners, *then* tag `v0.9.0` for the real release. I can't verify per-OS Wails CI locally, so the dispatch run is the shakeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)