### PR TITLE
gui: stop defaulting to demo data; cache last-known state + configurable auto-refresh

### DIFF
--- a/gui/app.go
+++ b/gui/app.go
@@ -19,7 +19,7 @@ type App struct {
 // once the Wails runtime (and the app's full process environment) is up —
 // spawning ssh during construction, before wails.Run, is unreliable.
 func NewApp(s Settings) *App {
-	return &App{settings: s, src: newMockSource()}
+	return &App{settings: s, src: emptySource{}}
 }
 
 func (a *App) startup(ctx context.Context) {
@@ -44,8 +44,12 @@ func (a *App) applyConnection() error {
 		a.tun.close()
 		a.tun = nil
 	}
-	if a.settings.Mode != "socket" {
+	if a.settings.Mode == "mock" {
 		a.src = newMockSource()
+		return nil
+	}
+	if a.settings.Mode != "socket" {
+		a.src = emptySource{}
 		return nil
 	}
 	sock := a.settings.SocketPath
@@ -58,8 +62,21 @@ func (a *App) applyConnection() error {
 		a.tun = t
 		sock = t.localSock
 	}
-	a.src = newSocketSource(sock)
+	src := newSocketSource(sock)
+	src.cache = newDiskCache(cachePath())
+	src.key = connectionKey(a.settings)
+	a.src = src
 	return nil
+}
+
+// connectionKey identifies which daemon a cache entry came from, so switching
+// hosts never surfaces the previous host's data. It is stable across reconnects
+// (the ssh tunnel's local socket path is not — it changes every run).
+func connectionKey(s Settings) string {
+	if s.SSHHost != "" {
+		return "ssh:" + s.SSHHost + ":" + s.RemoteSocket
+	}
+	return "sock:" + s.SocketPath
 }
 
 func (a *App) source() DataSource {

--- a/gui/app_test.go
+++ b/gui/app_test.go
@@ -41,6 +41,12 @@ func TestApplyConnection_SelectsSource(t *testing.T) {
 	}
 }
 
+func TestDefaultSettings_AutoRefresh(t *testing.T) {
+	if got := defaultSettings().RefreshSec; got != 30 {
+		t.Errorf("default RefreshSec = %d, want 30", got)
+	}
+}
+
 func TestMockSource_RendersConnected(t *testing.T) {
 	// The frontend keys off Connected; without it the developer demo would render
 	// as the not-connected empty state.

--- a/gui/app_test.go
+++ b/gui/app_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+func TestCoerceMock(t *testing.T) {
+	cases := []struct {
+		mode string
+		flag bool
+		want string
+	}{
+		{"", false, ""},           // fresh install stays disconnected
+		{"socket", false, "socket"}, // configured connection preserved
+		{"mock", false, ""},         // persisted demo migrated away without the flag
+		{"", true, "mock"},          // flag opts the developer into demo
+		{"socket", true, "mock"},    // flag wins (developer override)
+	}
+	for _, c := range cases {
+		if got := coerceMock(c.mode, c.flag); got != c.want {
+			t.Errorf("coerceMock(%q, %v) = %q, want %q", c.mode, c.flag, got, c.want)
+		}
+	}
+}
+
+func TestApplyConnection_SelectsSource(t *testing.T) {
+	// Default (no mode) must be the empty source, never mock/demo data.
+	a := &App{settings: Settings{Mode: ""}}
+	if err := a.applyConnection(); err != nil {
+		t.Fatalf("applyConnection: %v", err)
+	}
+	if _, ok := a.src.(emptySource); !ok {
+		t.Errorf("default mode should select emptySource, got %T", a.src)
+	}
+
+	// Mock only when explicitly requested (mode already gated to the env flag).
+	a.settings = Settings{Mode: "mock"}
+	if err := a.applyConnection(); err != nil {
+		t.Fatalf("applyConnection: %v", err)
+	}
+	if _, ok := a.src.(*mockSource); !ok {
+		t.Errorf("mock mode should select mockSource, got %T", a.src)
+	}
+}
+
+func TestMockSource_RendersConnected(t *testing.T) {
+	// The frontend keys off Connected; without it the developer demo would render
+	// as the not-connected empty state.
+	d, err := newMockSource().Dashboard()
+	if err != nil {
+		t.Fatalf("mock Dashboard: %v", err)
+	}
+	if !d.Connected || d.Stale {
+		t.Errorf("mock dashboard should be connected and not stale, got connected=%v stale=%v", d.Connected, d.Stale)
+	}
+}
+
+func TestEmptySource_NoDataNoActions(t *testing.T) {
+	var s emptySource
+	d, err := s.Dashboard()
+	if err != nil {
+		t.Fatalf("empty Dashboard should not error: %v", err)
+	}
+	if d.Connected || d.Stale || len(d.Tailnets) != 0 {
+		t.Errorf("empty dashboard must be disconnected and empty, got %+v", d)
+	}
+	if det, _ := s.TailnetDetail("x"); det.Error == "" {
+		t.Error("empty detail should carry a not-connected error")
+	}
+	if s.AddTailnet(AddTailnetRequest{ID: "x"}) == nil {
+		t.Error("AddTailnet should be refused when not connected")
+	}
+	if s.RemoveTailnet("x") == nil {
+		t.Error("RemoveTailnet should be refused when not connected")
+	}
+}

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// diskCache persists the last-known-good daemon snapshot so a client that loses
+// its connection shows last-known data (stamped stale) instead of demo fixtures
+// or an empty screen. It lives on disk because socketSource is rebuilt on every
+// reconnect; the file survives reconnects and app restarts.
+//
+// Entries are tagged with a connection Key (which daemon they came from). A read
+// whose current key differs from the stored one is treated as a miss, and the
+// next write resets the file — so pointing the app at a different host never
+// surfaces the previous host's data mislabeled as current.
+type diskCache struct {
+	path string
+	mu   sync.Mutex
+}
+
+type cachedDetail struct {
+	Detail TailnetDetail `json:"detail"`
+	At     time.Time     `json:"at"`
+}
+
+type cacheFile struct {
+	Key       string                  `json:"key"`
+	Dashboard *Dashboard              `json:"dashboard,omitempty"`
+	DashAt    time.Time               `json:"dashAt"`
+	Details   map[string]cachedDetail `json:"details,omitempty"`
+}
+
+func cachePath() string {
+	return filepath.Join(filepath.Dir(settingsPath()), "cache.json")
+}
+
+func newDiskCache(path string) *diskCache { return &diskCache{path: path} }
+
+// read returns the on-disk cache, or an empty file if absent/corrupt.
+func (c *diskCache) read() cacheFile {
+	var cf cacheFile
+	if b, err := os.ReadFile(c.path); err == nil {
+		json.Unmarshal(b, &cf)
+	}
+	return cf
+}
+
+// forKey returns the cache contents only if they belong to the given connection
+// key; otherwise an empty file (a miss), so a stale entry from a different
+// daemon is never used.
+func (c *diskCache) forKey(key string) cacheFile {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cf := c.read()
+	if cf.Key != key {
+		return cacheFile{Key: key}
+	}
+	return cf
+}
+
+// putDashboard stores the last-good dashboard under key, resetting the file if
+// the key changed (a different daemon).
+func (c *diskCache) putDashboard(key string, d Dashboard, at time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cf := c.read()
+	if cf.Key != key {
+		cf = cacheFile{Key: key}
+	}
+	snap := d
+	cf.Dashboard = &snap
+	cf.DashAt = at
+	c.write(cf)
+}
+
+// putDetail stores one tailnet's last-good detail under key.
+func (c *diskCache) putDetail(key, id string, d TailnetDetail, at time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cf := c.read()
+	if cf.Key != key {
+		cf = cacheFile{Key: key}
+	}
+	if cf.Details == nil {
+		cf.Details = map[string]cachedDetail{}
+	}
+	cf.Details[id] = cachedDetail{Detail: d, At: at}
+	c.write(cf)
+}
+
+// write persists cf; caller holds the lock. Failures are best-effort (the cache
+// is an optimization, not a source of truth).
+func (c *diskCache) write(cf cacheFile) {
+	if err := os.MkdirAll(filepath.Dir(c.path), 0700); err != nil {
+		return
+	}
+	if b, err := json.MarshalIndent(cf, "", "  "); err == nil {
+		os.WriteFile(c.path, b, 0600)
+	}
+}
+
+// lastSeenLabel renders a cached-at time for the UI ("15:04" today, else date).
+func lastSeenLabel(at time.Time) string {
+	if at.IsZero() {
+		return ""
+	}
+	return at.Format("Jan 2 15:04")
+}

--- a/gui/datasource.go
+++ b/gui/datasource.go
@@ -17,6 +17,21 @@ type DataSource interface {
 	RemoveTailnet(id string) error
 }
 
+// errNotConnected is returned by emptySource for actions that need a daemon.
+var errNotConnected = fmt.Errorf("not connected — open Settings to connect to a daemon")
+
+// emptySource is the default when no connection is configured. It shows nothing
+// (not demo data): an empty, explicitly-not-connected dashboard so the UI can
+// prompt the user to connect. Mutations are refused.
+type emptySource struct{}
+
+func (emptySource) Dashboard() (Dashboard, error) { return Dashboard{Connected: false}, nil }
+func (emptySource) TailnetDetail(id string) (TailnetDetail, error) {
+	return TailnetDetail{ID: id, Error: errNotConnected.Error()}, nil
+}
+func (emptySource) AddTailnet(AddTailnetRequest) error { return errNotConnected }
+func (emptySource) RemoveTailnet(string) error         { return errNotConnected }
+
 // mockSource holds mutable in-memory state so add/remove actually change what
 // the dashboard shows — the app is a faithful, daemon-less demo of the flow.
 type mockSource struct {
@@ -72,8 +87,9 @@ func (m *mockSource) Dashboard() (Dashboard, error) {
 			Tailnets: len(m.tailnets), Reconnecting: reconnecting, Peers: peers,
 			HostAccessOn: haOn, ReconcileSec: 10, Uptime: "2:59",
 		},
-		Tailnets: append([]TailnetRow(nil), m.tailnets...),
-		Events:   append([]Event(nil), m.events...),
+		Tailnets:  append([]TailnetRow(nil), m.tailnets...),
+		Events:    append([]Event(nil), m.events...),
+		Connected: true,
 	}, nil
 }
 

--- a/gui/frontend/dist/index.html
+++ b/gui/frontend/dist/index.html
@@ -578,6 +578,7 @@ body { margin:0; }
       <div class="cfb" style="padding:6px 22px 16px;display:flex;flex-direction:column;gap:13px">
         <div class="ff"><label class="l">SSH host <span style="text-transform:none;letter-spacing:0;color:var(--dim)">— blank for local</span></label><input type="text" id="set-ssh" placeholder="user@host"></div>
         <div class="ff"><label class="l">Daemon socket path</label><input type="text" id="set-sock" placeholder="/var/lib/hydrascale/api.sock"></div>
+        <div class="ff"><label class="l">Auto-refresh <span style="text-transform:none;letter-spacing:0;color:var(--dim)">— seconds, 0 = off</span></label><input type="number" id="set-refresh" min="0" step="5" placeholder="30"></div>
         <div class="cfnote" style="margin:0">Remote over SSH needs the daemon's <code>socket_group</code> set and your SSH user added to that group — otherwise its root-only socket refuses the forward.</div>
         <div id="set-err" style="display:none;color:var(--crit);font-size:12px;font-family:var(--mono)"></div>
       </div>
@@ -846,6 +847,31 @@ body { margin:0; }
       });
     }
 
+    // ---- auto-refresh ----
+    // Re-fetch the active view on an interval so a client recovers from an
+    // offline daemon on its own. Ticks never stack: a socket fetch can take up
+    // to 12s, so a tick is skipped while the previous one is still in flight.
+    var refreshTimer = null;
+    var refreshing = false;
+    function tickRefresh() {
+      if (refreshing) return;
+      refreshing = true;
+      var done = function () { refreshing = false; };
+      var vd = document.getElementById('v-detail');
+      var p = (vd && !vd.hidden && currentDetailId)
+        ? App.GetTailnetDetail(currentDetailId).then(renderDetail)
+        : refresh();
+      Promise.resolve(p).then(done, done);
+    }
+    function setAutoRefresh(sec) {
+      if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; }
+      sec = parseInt(sec, 10) || 0;
+      if (sec > 0) {
+        if (sec < 5) sec = 5; // floor: don't hammer the tunnel
+        refreshTimer = setInterval(tickRefresh, sec * 1000);
+      }
+    }
+
     // ---- detail view ----
     var currentDetailId = null;
 
@@ -945,6 +971,7 @@ body { margin:0; }
       App.GetSettings().then(function (s) {
         document.getElementById('set-ssh').value = s.sshHost || '';
         document.getElementById('set-sock').value = (s.sshHost ? s.remoteSocket : s.socketPath) || '/var/lib/hydrascale/api.sock';
+        document.getElementById('set-refresh').value = (s.refreshSec != null ? s.refreshSec : 30);
         document.getElementById('set-err').style.display = 'none';
         settingsM.hidden = false;
       });
@@ -954,10 +981,14 @@ body { margin:0; }
     document.getElementById('set-save').addEventListener('click', function () {
       var ssh = document.getElementById('set-ssh').value.trim();
       var sock = document.getElementById('set-sock').value.trim() || '/var/lib/hydrascale/api.sock';
+      var refreshSec = parseInt(document.getElementById('set-refresh').value, 10);
+      if (isNaN(refreshSec) || refreshSec < 0) refreshSec = 0;
+      if (refreshSec > 0 && refreshSec < 5) refreshSec = 5;
       var errEl = document.getElementById('set-err');
       errEl.style.display = 'none';
-      App.SaveSettings({ mode: 'socket', sshHost: ssh, socketPath: sock, remoteSocket: sock }).then(function () {
+      App.SaveSettings({ mode: 'socket', sshHost: ssh, socketPath: sock, remoteSocket: sock, refreshSec: refreshSec }).then(function () {
         settingsM.hidden = true;
+        setAutoRefresh(refreshSec);
         refresh();
       }).catch(function (e) {
         errEl.textContent = String(e).replace(/^Error:\s*/, '');
@@ -1028,6 +1059,7 @@ body { margin:0; }
 
     clearDashboardDOM(); // drop the baked-in mockup before the first fetch resolves
     refresh();
+    App.GetSettings().then(function (s) { setAutoRefresh(s.refreshSec); });
   })();
 </script>
 </body>

--- a/gui/frontend/dist/index.html
+++ b/gui/frontend/dist/index.html
@@ -689,6 +689,41 @@ body { margin:0; }
     };
     var SPARK = '<svg viewBox="0 0 64 20" preserveAspectRatio="none"><polyline points="0,13 9,12 18,11 27,12 36,10 45,11 54,9 64,10"/></svg>';
 
+    // ---- connection state: banner + clearing demo markup ----
+    // The static page ships with mockup rows baked into the DOM (the design
+    // preview). Inside Wails we must never let those read as real data, so we
+    // blank them on startup and render an explicit not-connected / stale state.
+    function banner() {
+      var b = document.getElementById('conn-banner');
+      if (!b) {
+        b = document.createElement('div');
+        b.id = 'conn-banner';
+        b.style.cssText = 'display:none;position:sticky;top:0;z-index:20;padding:7px 34px;' +
+          'font-size:12.5px;font-weight:600;letter-spacing:.2px;';
+        var mw = document.querySelector('.mainwrap');
+        if (mw) mw.insertBefore(b, mw.firstChild);
+      }
+      return b;
+    }
+    function setBanner(kind, text) {
+      var b = banner();
+      if (!kind) { b.style.display = 'none'; return; }
+      b.style.background = kind === 'stale' ? '#5a4300' : '#5a1b1b';
+      b.style.color = kind === 'stale' ? '#ffd257' : '#ff9d9d';
+      b.textContent = text;
+      b.style.display = 'block';
+    }
+    function clearDashboardDOM() {
+      var set = function (s, v) { var e = $(s); if (e) e.innerHTML = v; };
+      set('#v-list .metrics', '');
+      set('#v-list .tbl tbody', '');
+      set('#v-list .log .evs', '');
+      set('.hd .st', '');
+      set('.statusbar', '');
+      var c = $('#v-list .ph .c'); if (c) c.textContent = '0';
+      var crumb = $('#v-list .hd .crumb'); if (crumb) crumb.innerHTML = 'tailnets';
+    }
+
     function tailnetRow(t) {
       var dot = t.status === 'reconnecting' ? 'warn' : 'good';
       var addr = t.status === 'reconnecting'
@@ -719,42 +754,83 @@ body { margin:0; }
     }
 
     function renderDashboard(d) {
-      var m = d.metrics;
+      d = d || {};
+      var m = d.metrics || {};
+      var tailnets = d.tailnets || [];
+      var connected = !!d.connected;
+      var stale = !!d.stale;
+      var haveData = connected || stale;
+
+      if (connected) {
+        setBanner(null);
+      } else if (stale) {
+        setBanner('stale', 'Offline — showing last-known state' + (d.lastSeen ? ' · last seen ' + d.lastSeen : ''));
+      } else {
+        setBanner('error', d._error ? ('Not connected — ' + d._error) : 'Not connected — open Settings to connect to a daemon');
+      }
+
       var metrics = $('#v-list .metrics');
       if (metrics) {
-        metrics.innerHTML =
-          metric('Tailnets', m.tailnets + (m.reconnecting ? ' <small>· ' + m.reconnecting + ' reconnecting</small>' : '')) +
-          metric('Peers', m.peers) +
-          metric('Host access', '<span class="d good"></span>' + m.hostAccessOn + ' / ' + m.tailnets) +
-          metric('Reconcile', m.reconcileSec + '<small>s</small>') +
-          metric('Uptime', m.uptime);
+        metrics.innerHTML = haveData
+          ? metric('Tailnets', (m.tailnets || 0) + (m.reconnecting ? ' <small>· ' + m.reconnecting + ' reconnecting</small>' : '')) +
+            metric('Peers', m.peers || 0) +
+            metric('Host access', '<span class="d good"></span>' + (m.hostAccessOn || 0) + ' / ' + (m.tailnets || 0)) +
+            metric('Reconcile', (m.reconcileSec || 0) + '<small>s</small>') +
+            metric('Uptime', m.uptime || '—')
+          : '';
       }
       var tbody = $('#v-list .tbl tbody');
-      if (tbody) tbody.innerHTML = d.tailnets.map(tailnetRow).join('');
+      if (tbody) {
+        tbody.innerHTML = tailnets.length
+          ? tailnets.map(tailnetRow).join('')
+          : '<tr><td colspan="7" style="padding:22px 20px;color:var(--dim)">' +
+            (stale ? 'No tailnets in last-known state.' : 'Not connected. Open Settings to connect to a daemon.') +
+            '</td></tr>';
+      }
       var count = $('#v-list .ph .c');
-      if (count) count.textContent = d.tailnets.length;
+      if (count) count.textContent = tailnets.length;
       var evs = $('#v-list .log .evs');
-      if (evs) evs.innerHTML = d.events.map(eventRow).join('');
+      if (evs) evs.innerHTML = (d.events || []).map(eventRow).join('') ||
+        '<div class="e info" style="padding:12px 14px"><div class="m">No activity.</div></div>';
+
+      var crumb = $('#v-list .hd .crumb');
+      if (crumb) crumb.innerHTML = haveData
+        ? 'host <span class="mono">' + esc(d.host || '—') + '</span> / tailnets' + (stale ? ' <span style="color:#ffd257">(cached)</span>' : '')
+        : 'tailnets';
 
       var st = $('.hd .st');
       if (st) {
-        st.innerHTML =
-          '<span class="i"><span class="d good"></span><b>' + d.healthy + '</b> healthy</span>' +
-          '<span class="i"><b>' + m.peers + '</b> peers</span>' +
-          '<span class="i"><span class="d ' + (d.dnsOk ? 'good' : 'crit') + '"></span>DNS</span>';
+        st.innerHTML = haveData
+          ? '<span class="i"><span class="d ' + (connected ? 'good' : 'warn') + '"></span><b>' + (d.healthy || 0) + '</b> healthy</span>' +
+            '<span class="i"><b>' + (m.peers || 0) + '</b> peers</span>' +
+            '<span class="i"><span class="d ' + (d.dnsOk ? 'good' : 'crit') + '"></span>DNS</span>'
+          : '';
       }
       var sb = $('.statusbar');
       if (sb) {
-        sb.innerHTML =
-          '<span><span class="d good"></span>Daemon healthy</span>' +
-          '<span>reconcile ' + m.reconcileSec + 's</span>' +
-          '<span>host ' + esc(d.host) + '</span>' +
-          '<span style="margin-left:auto">' + d.tailnets.length + ' tailnets · ' + m.peers + ' peers</span>' +
-          '<span>hydrascale' + (d.version ? ' ' + esc(d.version) : '') + '</span>';
+        if (connected) {
+          sb.innerHTML =
+            '<span><span class="d good"></span>Daemon healthy</span>' +
+            '<span>reconcile ' + (m.reconcileSec || 0) + 's</span>' +
+            '<span>host ' + esc(d.host || '—') + '</span>' +
+            '<span style="margin-left:auto">' + tailnets.length + ' tailnets · ' + (m.peers || 0) + ' peers</span>' +
+            '<span>hydrascale' + (d.version ? ' ' + esc(d.version) : '') + '</span>';
+        } else if (stale) {
+          sb.innerHTML =
+            '<span><span class="d warn"></span>Offline</span>' +
+            (d.lastSeen ? '<span>last seen ' + esc(d.lastSeen) + '</span>' : '') +
+            '<span>host ' + esc(d.host || '—') + ' (cached)</span>' +
+            '<span style="margin-left:auto">' + tailnets.length + ' tailnets · ' + (m.peers || 0) + ' peers</span>';
+        } else {
+          sb.innerHTML =
+            '<span><span class="d crit"></span>Not connected</span>' +
+            '<span style="margin-left:auto">Open Settings to connect</span>';
+        }
       }
       // Rebound rows: fetch + render the detail view from Go on click.
       Array.prototype.forEach.call(document.querySelectorAll('#v-list .tbl tbody tr'), function (tr) {
-        tr.addEventListener('click', function () { openDetail(tr.getAttribute('data-id')); });
+        var id = tr.getAttribute('data-id');
+        if (id) tr.addEventListener('click', function () { openDetail(id); });
       });
     }
 
@@ -765,6 +841,8 @@ body { margin:0; }
     function refresh() {
       return App.GetDashboard().then(renderDashboard).catch(function (e) {
         console.error('GetDashboard failed', e);
+        renderDashboard({ connected: false, stale: false, tailnets: [], events: [], metrics: {},
+          _error: String(e).replace(/^Error:\s*/, '') });
       });
     }
 
@@ -792,10 +870,12 @@ body { margin:0; }
 
     function renderDetail(d) {
       var root = document.getElementById('v-detail');
-      if (d.error) { console.error('detail:', d.error); }
+      if (d.error) { setBanner('error', 'Not connected — ' + d.error); }
+      else if (d.stale) { setBanner('stale', 'Offline — last-known detail' + (d.lastSeen ? ' · last seen ' + d.lastSeen : '')); }
+      else { setBanner(null); }
       var crumb = $('.crumb', root);
-      if (crumb) crumb.innerHTML = 'host <span class="mono">' + esc(d.namespace ? 'mars' : 'mars') +
-        '</span> / <span class="mono" style="color:var(--muted)">' + esc(d.id) + '</span>';
+      if (crumb) crumb.innerHTML = 'tailnet <span class="mono">' + esc(d.id) + '</span>' +
+        (d.stale ? ' <span style="color:#ffd257">(cached)</span>' : '');
       var metrics = $('.metrics', root);
       if (metrics) metrics.innerHTML =
         '<div class="m"><span class="k">Status</span><span class="v"><span class="d ' +
@@ -946,6 +1026,7 @@ body { margin:0; }
     var railActivity = document.querySelector('.nb[title="Activity"]');
     if (railActivity) railActivity.addEventListener('click', showActivity);
 
+    clearDashboardDOM(); // drop the baked-in mockup before the first fetch resolves
     refresh();
   })();
 </script>

--- a/gui/settings.go
+++ b/gui/settings.go
@@ -16,6 +16,7 @@ type Settings struct {
 	SocketPath   string `json:"socketPath"`   // used when Mode=="socket" and no SSH host
 	SSHHost      string `json:"sshHost"`      // when set, the app forwards RemoteSocket over ssh
 	RemoteSocket string `json:"remoteSocket"` // daemon socket path on the SSH host
+	RefreshSec   int    `json:"refreshSec"`   // auto-refresh interval in seconds; 0 = off
 }
 
 func defaultSettings() Settings {
@@ -23,6 +24,7 @@ func defaultSettings() Settings {
 		Mode:         "", // not connected by default — never demo data
 		SocketPath:   "/var/lib/hydrascale/api.sock",
 		RemoteSocket: "/var/lib/hydrascale/api.sock",
+		RefreshSec:   30,
 	}
 }
 

--- a/gui/settings.go
+++ b/gui/settings.go
@@ -12,7 +12,7 @@ import (
 
 // Settings is the user's persisted connection configuration.
 type Settings struct {
-	Mode         string `json:"mode"`         // "mock" | "socket"
+	Mode         string `json:"mode"`         // "" (not connected) | "socket" | "mock"
 	SocketPath   string `json:"socketPath"`   // used when Mode=="socket" and no SSH host
 	SSHHost      string `json:"sshHost"`      // when set, the app forwards RemoteSocket over ssh
 	RemoteSocket string `json:"remoteSocket"` // daemon socket path on the SSH host
@@ -20,10 +20,23 @@ type Settings struct {
 
 func defaultSettings() Settings {
 	return Settings{
-		Mode:         "mock",
+		Mode:         "", // not connected by default — never demo data
 		SocketPath:   "/var/lib/hydrascale/api.sock",
 		RemoteSocket: "/var/lib/hydrascale/api.sock",
 	}
+}
+
+// coerceMock enforces "mock is developer-only, never a default": mock is used
+// solely when the flag is set; a persisted mode:"mock" without the flag (from an
+// older build) is migrated to "" so returning users are never stuck on demo data.
+func coerceMock(mode string, mockFlag bool) string {
+	if mockFlag {
+		return "mock"
+	}
+	if mode == "mock" {
+		return ""
+	}
+	return mode
 }
 
 func settingsPath() string {
@@ -39,6 +52,11 @@ func loadSettings() Settings {
 	if b, err := os.ReadFile(settingsPath()); err == nil {
 		json.Unmarshal(b, &s)
 	}
+	// Mock (demo) data is opt-in for the developer only, never a default: it is
+	// reachable solely via HYDRASCALE_MOCK=1. A persisted mode:"mock" from an
+	// older build is migrated away unless the flag is set, so returning users are
+	// never stuck on demo data.
+	s.Mode = coerceMock(s.Mode, os.Getenv("HYDRASCALE_MOCK") == "1")
 	// Dev/test override: HYDRASCALE_SOCKET forces socket mode at a path.
 	if sock := os.Getenv("HYDRASCALE_SOCKET"); sock != "" {
 		s.Mode = "socket"

--- a/gui/socketsource.go
+++ b/gui/socketsource.go
@@ -18,7 +18,9 @@ import (
 // forward of the daemon's /var/lib/hydrascale/api.sock; locally on Linux it is
 // that path directly. It maps the daemon's JSON onto the GUI's view-model DTOs.
 type socketSource struct {
-	http *http.Client
+	http  *http.Client
+	cache *diskCache // last-known-good snapshot; nil disables caching (used in mapping tests)
+	key   string     // connection identity the cache is tagged with
 }
 
 func newSocketSource(socketPath string) *socketSource {
@@ -129,7 +131,7 @@ type apiEvents struct {
 func (s *socketSource) Dashboard() (Dashboard, error) {
 	var cfg apiConfig
 	if err := s.get("/api/config", &cfg); err != nil {
-		return Dashboard{}, err
+		return s.staleDashboard(err)
 	}
 	var st apiStatus
 	_ = s.get("/api/status", &st) // health is best-effort; config drives the list
@@ -187,7 +189,7 @@ func (s *socketSource) Dashboard() (Dashboard, error) {
 		})
 	}
 
-	return Dashboard{
+	d := Dashboard{
 		Host:    hostName(st),
 		Healthy: healthy,
 		DNSOK:   true,
@@ -196,9 +198,30 @@ func (s *socketSource) Dashboard() (Dashboard, error) {
 			Tailnets: len(rows), Reconnecting: reconnecting, Peers: peersTotal,
 			HostAccessOn: haOn, ReconcileSec: 10, Uptime: "",
 		},
-		Tailnets: rows,
-		Events:   s.events(),
-	}, nil
+		Tailnets:  rows,
+		Events:    s.events(),
+		Connected: true,
+	}
+	if s.cache != nil {
+		s.cache.putDashboard(s.key, d, time.Now())
+	}
+	return d, nil
+}
+
+// staleDashboard is returned when the daemon is unreachable: the last-known
+// snapshot stamped stale, or — with nothing cached — an empty "not connected"
+// dashboard carrying the underlying error so the UI can show it.
+func (s *socketSource) staleDashboard(cause error) (Dashboard, error) {
+	if s.cache != nil {
+		if cf := s.cache.forKey(s.key); cf.Dashboard != nil {
+			d := *cf.Dashboard
+			d.Connected = false
+			d.Stale = true
+			d.LastSeen = lastSeenLabel(cf.DashAt)
+			return d, nil
+		}
+	}
+	return Dashboard{Connected: false}, cause
 }
 
 // hostName derives the host label from a namespace name like "mars-1" → "mars".
@@ -250,7 +273,7 @@ func eventKind(t string) string {
 func (s *socketSource) TailnetDetail(id string) (TailnetDetail, error) {
 	var d apiDetail
 	if err := s.get("/api/tailnet/"+id+"/detail", &d); err != nil {
-		return TailnetDetail{ID: id, Error: err.Error()}, nil
+		return s.staleDetail(id, err), nil
 	}
 	if d.Error != "" {
 		return TailnetDetail{ID: id, Error: d.Error}, nil
@@ -326,12 +349,32 @@ func (s *socketSource) TailnetDetail(id string) (TailnetDetail, error) {
 	if st.ErrorStates[id] || !st.Actual[id].DaemonHealthy {
 		status = "reconnecting"
 	}
-	return TailnetDetail{
+	detail := TailnetDetail{
 		ID: id, Namespace: emptyOr(nsName, "ns-"+id), Status: status,
 		Address: ipv4, PeerCount: d.PeerCount, Uptime: "",
 		Network: network, DNS: dns, HostAccess: ha, Routes: routes,
 		Peers: peers, Events: s.events(),
-	}, nil
+	}
+	if s.cache != nil {
+		s.cache.putDetail(s.key, id, detail, time.Now())
+	}
+	return detail, nil
+}
+
+// staleDetail is returned when the daemon is unreachable while opening a detail
+// view: the last-known detail stamped stale, or the error if nothing is cached.
+func (s *socketSource) staleDetail(id string, cause error) TailnetDetail {
+	if s.cache != nil {
+		if cf := s.cache.forKey(s.key); cf.Details != nil {
+			if cd, ok := cf.Details[id]; ok {
+				d := cd.Detail
+				d.Stale = true
+				d.LastSeen = lastSeenLabel(cd.At)
+				return d
+			}
+		}
+	}
+	return TailnetDetail{ID: id, Error: cause.Error()}
 }
 
 func (s *socketSource) AddTailnet(req AddTailnetRequest) error {

--- a/gui/socketsource_test.go
+++ b/gui/socketsource_test.go
@@ -115,3 +115,73 @@ func TestSocketSource_DetailError(t *testing.T) {
 		t.Error("expected error surfaced for beta (daemon starting)")
 	}
 }
+
+// cachedPair builds a live source (against a fake daemon) and a "dead" source
+// (dialing a socket that doesn't exist) that share one on-disk cache and key —
+// modelling a reconnect after the daemon went away.
+func cachedPair(t *testing.T, key string) (live, dead *socketSource) {
+	t.Helper()
+	cache := newDiskCache(filepath.Join(t.TempDir(), "cache.json"))
+	live = newSocketSource(fakeDaemon(t))
+	live.cache, live.key = cache, key
+	dead = newSocketSource(filepath.Join(t.TempDir(), "gone.sock"))
+	dead.cache, dead.key = cache, key
+	return live, dead
+}
+
+func TestStaleDashboard(t *testing.T) {
+	live, dead := cachedPair(t, "k1")
+	if _, err := live.Dashboard(); err != nil {
+		t.Fatalf("live Dashboard: %v", err)
+	}
+	d, err := dead.Dashboard()
+	if err != nil {
+		t.Fatalf("stale dashboard should not error: %v", err)
+	}
+	if !d.Stale || d.Connected {
+		t.Errorf("want stale && !connected, got stale=%v connected=%v", d.Stale, d.Connected)
+	}
+	if len(d.Tailnets) != 2 {
+		t.Errorf("stale dashboard should carry cached rows, got %d", len(d.Tailnets))
+	}
+	if d.LastSeen == "" {
+		t.Error("stale dashboard needs a LastSeen label")
+	}
+}
+
+func TestStaleDetail(t *testing.T) {
+	live, dead := cachedPair(t, "k1")
+	if _, err := live.TailnetDetail("alpha"); err != nil {
+		t.Fatalf("live detail: %v", err)
+	}
+	d, _ := dead.TailnetDetail("alpha")
+	if !d.Stale || d.Error != "" {
+		t.Errorf("want stale detail with no error, got stale=%v err=%q", d.Stale, d.Error)
+	}
+	if len(d.Peers) != 2 || d.LastSeen == "" {
+		t.Errorf("stale detail should carry cached peers + LastSeen: %+v", d)
+	}
+}
+
+func TestNoCacheError(t *testing.T) {
+	dead := newSocketSource(filepath.Join(t.TempDir(), "gone.sock")) // cache == nil
+	d, err := dead.Dashboard()
+	if err == nil {
+		t.Fatal("unreachable daemon with no cache must return an error")
+	}
+	if d.Connected || d.Stale || len(d.Tailnets) != 0 {
+		t.Errorf("no-cache failure must be empty+disconnected, got %+v", d)
+	}
+}
+
+func TestCacheKeyMismatch(t *testing.T) {
+	live, dead := cachedPair(t, "k1")
+	if _, err := live.Dashboard(); err != nil {
+		t.Fatalf("live Dashboard: %v", err)
+	}
+	dead.key = "different-daemon" // e.g. user re-pointed the app at another host
+	_, err := dead.Dashboard()
+	if err == nil {
+		t.Error("cache from a different daemon key must not be served; expected error")
+	}
+}

--- a/gui/types.go
+++ b/gui/types.go
@@ -45,14 +45,22 @@ type Event struct {
 }
 
 // Dashboard is the whole list view, assembled by the backend in one call.
+//
+// Connection state drives what the frontend shows so it never falls back to
+// stale markup: Connected means the data is live; Stale means the daemon is
+// unreachable and this is the last-known snapshot (LastSeen says when); both
+// false with empty Tailnets means "not connected, nothing cached".
 type Dashboard struct {
-	Host     string       `json:"host"`
-	Healthy  int          `json:"healthy"`
-	DNSOK    bool         `json:"dnsOk"`
-	Version  string       `json:"version"`
-	Metrics  Metrics      `json:"metrics"`
-	Tailnets []TailnetRow `json:"tailnets"`
-	Events   []Event      `json:"events"`
+	Host      string       `json:"host"`
+	Healthy   int          `json:"healthy"`
+	DNSOK     bool         `json:"dnsOk"`
+	Version   string       `json:"version"`
+	Metrics   Metrics      `json:"metrics"`
+	Tailnets  []TailnetRow `json:"tailnets"`
+	Events    []Event      `json:"events"`
+	Connected bool         `json:"connected"`
+	Stale     bool         `json:"stale"`
+	LastSeen  string       `json:"lastSeen"` // human time of the cached snapshot, when Stale
 }
 
 // Peer is one row in a tailnet's peers table.
@@ -87,4 +95,6 @@ type TailnetDetail struct {
 	Peers      []Peer  `json:"peers"`
 	Events     []Event `json:"events"`
 	Error      string  `json:"error,omitempty"`
+	Stale      bool    `json:"stale"`
+	LastSeen   string  `json:"lastSeen"` // human time of the cached snapshot, when Stale
 }


### PR DESCRIPTION
## Problem

The shipped GUI served **fabricated demo data out of the box**, mistakable for a real deployment. Two independent causes:

1. **Default source was mock.** `defaultSettings()` defaulted `Mode` to `"mock"`, so any fresh install with no configured connection rendered the built-in fixtures (`mars`, jbones/havoc/etc.).
2. **Frontend baked demo rows into the static DOM** and only overwrote them on a *successful* render — so failures left the fake rows (and a hard-coded "Daemon healthy" statusbar) on screen. There is no silent socket→mock fallback, so "host offline" was a red herring: the app was never connected.

## Changes

- **Default is now "not connected"** → new `emptySource` shows an explicit empty state, never demo data. **Mock is developer-only** (`HYDRASCALE_MOCK=1`); a persisted `mode:"mock"` from older builds is migrated away unless the flag is set.
- **Disk cache** (`cache.json`, keyed by connection identity): a client that loses its daemon shows the **last-known dashboard + per-tailnet detail**, stamped `stale · last seen <time>`, instead of an error or demo data. A different daemon's cache is never served.
- **Frontend** clears the mockup on startup and renders three honest states: live / stale / not-connected. Fixes the hard-coded "Daemon healthy" statusbar.
- **Configurable auto-refresh** (`Settings.RefreshSec`, seconds, `0` = off, default 30) in the Settings modal. Re-fetches the active view on an interval so an offline client recovers on its own; ticks never stack (skipped while a fetch is in flight), non-zero values floored to 5s.

## Verification

- `go test ./...` + `go vet` pass — cache/stale/empty/mock-gating logic against a fake daemon, default-interval test.
- jsdom render checks: 16/16 for the three UI states; 6/6 for auto-refresh (interval wiring, 5s floor, `0`=off, in-flight overlap guard, settings round-trip).
- `go build` verifies the frontend embed. `wails build` not run locally (not on PATH); CI builds per-OS.

## Scope notes

- No behavior change for a live, connected daemon.
- The auto-refresh tick re-fetches over the *existing* connection; a dead SSH tunnel (not just a stopped daemon) still needs a manual reconnect via Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)